### PR TITLE
yiimp: catch additional errors for failed payment tx's

### DIFF
--- a/web/yaamp/core/backend/payment.php
+++ b/web/yaamp/core/backend/payment.php
@@ -67,7 +67,7 @@ function BackendCoinPayments($coin)
 				if(!$tx)
 				{
 					debuglog("error $remote->error, $user->username, $amount");
-					if($remote->error == 'transaction too large' || $remote->error == 'invalid amount')
+					if($remote->error == 'transaction too large' || $remote->error == 'invalid amount' || $remote->error == 'insufficient funds' || $remote->error == 'error: transaction creation failed  ')
 					{
 						$coin->payout_max = min((double) $amount, (double) $coin->payout_max);
 						$coin->save();


### PR DESCRIPTION
Added some additional errors to catch for failed miner payments and to resend 1/2 the failed amount.