### PR TITLE
Fix for difficuly/decred confusion (#60)

### DIFF
--- a/stratum/client_difficulty.cpp
+++ b/stratum/client_difficulty.cpp
@@ -83,9 +83,15 @@ int client_send_difficulty(YAAMP_CLIENT *client, double difficulty)
 
 void client_initialize_difficulty(YAAMP_CLIENT *client)
 {
-	char *p = strstr(client->password, "d=");
-	char *p2 = strstr(client->password, "decred=");
-	if(!p || p2) return;
+	char *p = client->password;
+	char *p2 = strstr(client->password, "decred=") + sizeof(char)*6;
+
+        while ( (p=strstr(p,"d=")) != NULL ) {
+                if (p != p2) break;
+                p++;
+        }
+
+	if(!p) return;
 
 	double diff = client_normalize_difficulty(atof(p+2));
 	uint64_t user_target = diff_to_target(diff);


### PR DESCRIPTION
Just a quick fix. Make sure the `d=` is not part of `decred=`. This can still fail if there are multiple `decred=`, so we're relying on the user to not make that mistake.
A more robust solution would be to actually split up the password string into a hash table or something.