### PR TITLE
remove unnecessary and broken definition

### DIFF
--- a/web/yaamp/modules/explorer/tx.php
+++ b/web/yaamp/modules/explorer/tx.php
@@ -42,7 +42,6 @@ $coinUrl = $this->createUrl('/explorer', array('id'=>$coin->id));
 
 echo '<tr class="ssrow">';
 
-$url = ;
 echo '<td><span class="monospace">'.CHtml::link($tx['txid'], $coinUrl.'txid='.$tx['txid']).'</a></span></td>';
 echo '<td>'.$valuetx.'</td>';
 


### PR DESCRIPTION
Syntax error caused by something that doesn't event need to be there. As far as I can tell.