### PR TITLE
Fix for Nova trading

### DIFF
--- a/web/yaamp/core/trading/nova_trading.php
+++ b/web/yaamp/core/trading/nova_trading.php
@@ -169,11 +169,6 @@ function doNovaTrading($quick=false)
 			continue;
 		}
 
-		$market2 = getdbosql('db_markets', "coinid={$coin->id} AND (name='bittrex' OR name='poloniex')");
-		if ($market2) {
-			continue;
-		}
-
 		$market = getdbosql('db_markets', "coinid=$coin->id and name='{$exchange}'");
 		if ($market) {
 			$market->lasttraded = time();


### PR DESCRIPTION
Remove the check for poloniex or bittrex. Which stopped coins that also had polo or trex markets to fail to sell.