### PR TITLE
Fix for DNR/DSR confusion

### DIFF
--- a/stratum/coinbase.cpp
+++ b/stratum/coinbase.cpp
@@ -207,7 +207,7 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		strcmp(coind->symbol, "MUE") == 0 || // MUEcore-x11
 		strcmp(coind->symbol, "VIVO") == 0 || // VIVO coin
 	   	strcmp(coind->symbol, "INN") == 0 || // Innova coin
-	   	strcmp(coind->symbol, "DSR") == 0 || // Desire coin
+	   	strcmp(coind->symbol, "DESIRE") == 0 || // Desire coin
 		strcmp(coind->symbol, "DASH") == 0 || strcmp(coind->symbol, "DASH-TESTNET") == 0) // Dash 12.1
 	{
 		char script_dests[2048] = { 0 };


### PR DESCRIPTION
When Symbol is DSR, a confusion with DNR happens. So I changed the Symbol to DESIRE and official symbol to DSR. This issue didn't happen during tests because DNR is not set up on test environment.

Previous error in stratum log of neoscrypt:
2017-10-27 19:44:43 [188.188.45.238] DArwrg22fEod5vKDizWBtsFs2fq6LYXzg6, neoscrypt, unable to find the wallet for coinid 1425...

coinid 1425 is Denarius DNR

https://github.com/tpruvot/yiimp/pull/184