### PR TITLE
Fixed issue where the AverageIncrement function could return 80% 

### DIFF
--- a/web/yaamp/core/backend/markets.php
+++ b/web/yaamp/core/backend/markets.php
@@ -205,6 +205,14 @@ function getBestMarket($coin)
 
 function AverageIncrement($value1, $value2)
 {
+	if ($value1 == 0){
+		return $value2;
+	}
+
+	if ($value2 == 0){
+		return $value1;
+	}
+
 	$percent = 80;
 	$value = ($value1*(100-$percent) + $value2*$percent) / 100;
 


### PR DESCRIPTION
Found that the AverageIncrement function would only return 80% of the original value if it receives a 0 value from the input function.  This is causing significantly lower payouts for mined coins on pools with autoexchange enabled.  The change forces the function to return the existing or previous value if either of the inputs are 0.