### PR TITLE
stratum: allow non-standard port in database connection

### DIFF
--- a/stratum/db.cpp
+++ b/stratum/db.cpp
@@ -12,7 +12,7 @@ void db_reconnect(YAAMP_DB *db)
 	mysql_init(&db->mysql);
 	for(int i=0; i<6; i++)
 	{
-		MYSQL *p = mysql_real_connect(&db->mysql, g_sql_host, g_sql_username, g_sql_password, g_sql_database, 0, 0, 0);
+		MYSQL *p = mysql_real_connect(&db->mysql, g_sql_host, g_sql_username, g_sql_password, g_sql_database, g_sql_port, 0, 0);
 		if(p) break;
 
 		stratumlog("%d, %s\n", i, mysql_error(&db->mysql));

--- a/stratum/stratum.cpp
+++ b/stratum/stratum.cpp
@@ -23,6 +23,7 @@ char g_sql_host[1024];
 char g_sql_database[1024];
 char g_sql_username[1024];
 char g_sql_password[1024];
+int g_sql_port;
 
 char g_stratum_coin_include[256];
 char g_stratum_coin_exclude[256];
@@ -218,6 +219,7 @@ int main(int argc, char **argv)
 	strcpy(g_sql_database, iniparser_getstring(ini, "SQL:database", NULL));
 	strcpy(g_sql_username, iniparser_getstring(ini, "SQL:username", NULL));
 	strcpy(g_sql_password, iniparser_getstring(ini, "SQL:password", NULL));
+	g_sql_port = iniparser_getint(ini, "SQL:port", 3306);
 
 	// optional coin filters (to mine only one on a special port or a test instance)
 	char *coin_filter = iniparser_getstring(ini, "WALLETS:include", NULL);

--- a/stratum/stratum.h
+++ b/stratum/stratum.h
@@ -74,6 +74,7 @@ extern char g_sql_host[1024];
 extern char g_sql_database[1024];
 extern char g_sql_username[1024];
 extern char g_sql_password[1024];
+extern int g_sql_port;
 
 extern char g_stratum_coin_include[256];
 extern char g_stratum_coin_exclude[256];


### PR DESCRIPTION
Useful if using mysql-router or proxysql listing on different port