### PR TITLE
fix(explorer->coin): show info about first block

### DIFF
--- a/web/yaamp/modules/explorer/coin.php
+++ b/web/yaamp/modules/explorer/coin.php
@@ -51,7 +51,7 @@ echo "</thead>";
 
 $remote = new WalletRPC($coin);
 if (!$start || $start > $coin->block_height)
-	$start = $coin->block_height;
+	$start = (int)$coin->block_height;
 for($i = $start; $i > max(1, $start-21); $i--)
 {
 	$hash = $remote->getblockhash($i);


### PR DESCRIPTION
How to reproduce: you should open explorer information about one of the coin - http://yiimp.eu/explorer/BTX.
Now we don't see information about the last block, but when we go to the next page and then to the previous we see all blocks - http://yiimp.eu/explorer/BTX?start=118272. If we again delete query from the url we won't see the last block - 118272 on the current moment.