### PR TITLE
ci: add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: cpp
+script:
+  - (cd blocknotify && make)
+  - (cd stratum/iniparser && make)
+  - (cd stratum && make)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/tpruvot/yiimp.svg?branch=next)](https://travis-ci.org/tpruvot/yiimp)
+
 #yiimp - yaamp fork
 
 Required:


### PR DESCRIPTION
Recently there was a typo in one of the commit and code did not compile.
This adds basic travis-ci (http://travis-ci.org) configuration for checking on every pull request if everything compiles.
Travis-CI is free for use for open source projects