### PR TITLE
Add MAG (Magnet) masternode to oldmasternodes

### DIFF
--- a/stratum/db.cpp
+++ b/stratum/db.cpp
@@ -305,6 +305,7 @@ void db_update_coinds(YAAMP_DB *db)
 			if (strcmp(coind->symbol, "URALS") == 0) coind->oldmasternodes = true;
 			if (strcmp(coind->symbol, "VSX") == 0) coind->oldmasternodes = true;
 			if (strcmp(coind->symbol, "XLR") == 0) coind->oldmasternodes = true;
+			if (strcmp(coind->symbol, "MAG") == 0) coind->oldmasternodes = true;
 		}
 
 		////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Greetings, I am head dev for Magnet masternode and noticed the change made in coinbase.cpp (1d52379) for recent masternode RPC as default. This change has disabled masternode payments on pools using MAG client. So, we would like to add it to oldmasternodes list with this pull request.