### PR TITLE
Update x16r.conf : error with port

### DIFF
--- a/stratum/config.sample/x16r.conf
+++ b/stratum/config.sample/x16r.conf
@@ -1,6 +1,6 @@
 [TCP]
 server = yaamp.com
-port = 3737
+port = 3636
 password = tu8tu5
 
 [SQL]


### PR DESCRIPTION
Petite erreur sur le port utilisé pour x16r.
Le bon port est 3636 et pas 3737