### PR TITLE
Use `memcache` object instead of low level methods

### DIFF
--- a/web/yaamp/core/common/system.php
+++ b/web/yaamp/core/common/system.php
@@ -4,7 +4,7 @@ function send_email_alert($name, $title, $message, $t=10)
 {
 //	debuglog(__FUNCTION__);
 
-	$last = memcache_get(controller()->memcache->memcache, "last_email_sent_$name");
+	$last = controller()->memcache->get("last_email_sent_$name");
 	if($last + $t*60 > time()) return;
 
 	debuglog("mail('".YAAMP_ADMIN_EMAIL."', $title, ...)");
@@ -12,7 +12,7 @@ function send_email_alert($name, $title, $message, $t=10)
 	$b = mail(YAAMP_ADMIN_EMAIL, $title, $message);
 	if(!$b) debuglog('error sending email');
 
-	memcache_set(controller()->memcache->memcache, "last_email_sent_$name", time());
+	controller()->memcache->set("last_email_sent_$name", time());
 }
 
 function dos_filesize($fn)

--- a/web/yaamp/modules/api/ApiController.php
+++ b/web/yaamp/modules/api/ApiController.php
@@ -20,8 +20,7 @@ class ApiController extends CommonController
 			return;
 		}
 
-		$memcache = controller()->memcache->memcache;
-		$json = memcache_get($memcache, "api_status");
+		$json = controller()->memcache->get("api_status");
 
 		if (!empty($json)) {
 			echo $json;
@@ -97,7 +96,7 @@ class ApiController extends CommonController
 		$json = json_encode($stats);
 		echo $json;
 
-		memcache_set($memcache, "api_status", $json, MEMCACHE_COMPRESSED, 30);
+		controller()->memcache->set("api_status", $json, MEMCACHE_COMPRESSED, 30);
 	}
 
 	public function actionCurrencies()
@@ -112,9 +111,7 @@ class ApiController extends CommonController
 			return;
 		}
 
-		$memcache = controller()->memcache->memcache;
-
-		$json = memcache_get($memcache, "api_currencies");
+		$json = controller()->memcache->get("api_currencies");
 		if (empty($json)) {
 
 			$data = array();
@@ -186,7 +183,7 @@ class ApiController extends CommonController
 					$data[$symbol]['symbol'] = $coin->symbol2;
 			}
 			$json = json_encode($data);
-			memcache_set($memcache, "api_currencies", $json, MEMCACHE_COMPRESSED, 15);
+			controller()->memcache->set("api_currencies", $json, MEMCACHE_COMPRESSED, 15);
 		}
 
 		echo str_replace("},","},\n", $json);

--- a/web/yaamp/modules/site/SiteController.php
+++ b/web/yaamp/modules/site/SiteController.php
@@ -415,7 +415,7 @@ class SiteController extends CommonController
 		$algo = user()->getState('yaamp-algo');
 		$memcache = controller()->memcache->memcache;
 		$memkey = $algo.'_'.str_replace('/','_',$partial);
-		$html = memcache_get($memcache, $memkey);
+		$html = controller()->memcache->get($memkey);
 
 		if (!empty($html)) {
 			echo $html;
@@ -428,7 +428,7 @@ class SiteController extends CommonController
 		$html = ob_get_clean();
 		echo $html;
 
-		memcache_set($memcache, $memkey, $html, MEMCACHE_COMPRESSED, $cachetime);
+		controller()->memcache->set($memkey, $html, MEMCACHE_COMPRESSED, $cachetime);
 	}
 
 	// Pool Status : public right panel with all algos and live stats

--- a/web/yaamp/modules/site/common_results.php
+++ b/web/yaamp/modules/site/common_results.php
@@ -507,8 +507,8 @@ function cronstate2text($state)
 	}
 }
 
-//$state_block = memcache_get($this->memcache->memcache, 'cronjob_block_state');
-$state_main = memcache_get($this->memcache->memcache, 'cronjob_main_state');
+//$state_block = $this->memcache->get('cronjob_block_state');
+$state_main = $this->memcache->get('cronjob_main_state');
 $btc = getdbosql('db_coins', "symbol='BTC'");
 if (!$btc) $btc = json_decode('{"id": 6, "balance": 0}');
 
@@ -517,24 +517,24 @@ for($i=0; $i<10; $i++)
 {
 // 	if($i != $state_block-1 && $state_block>0)
 // 	{
-// 		$state = memcache_get($this->memcache->memcache, "cronjob_block_state_$i");
+// 		$state = $this->memcache->get("cronjob_block_state_$i");
 // 		if($state) echo "block $i ";
 // 	}
 
 	if($i != $state_main-1 && $state_main>0)
 	{
-		$state = memcache_get($this->memcache->memcache, "cronjob_main_state_$i");
+		$state = $this->memcache->get("cronjob_main_state_$i");
 		if($state) echo "main $i ";
 	}
 }
 
 echo '</span>';
 
-$block_time = sectoa(time()-memcache_get($this->memcache->memcache, "cronjob_block_time_start"));
-$loop2_time = sectoa(time()-memcache_get($this->memcache->memcache, "cronjob_loop2_time_start"));
-$main_time2 = sectoa(time()-memcache_get($this->memcache->memcache, "cronjob_main_time_start"));
+$block_time = sectoa(time()-$this->memcache->get("cronjob_block_time_start"));
+$loop2_time = sectoa(time()-$this->memcache->get("cronjob_loop2_time_start"));
+$main_time2 = sectoa(time()-$this->memcache->get("cronjob_main_time_start"));
 
-$main_time = sectoa(memcache_get($this->memcache->memcache, "cronjob_main_time"));
+$main_time = sectoa($this->memcache->get("cronjob_main_time"));
 $main_text = cronstate2text($state_main);
 
 echo "*** main  ($main_time) $state_main $main_text ($main_time2), loop2 ($loop2_time), block ($block_time)<br>";

--- a/web/yaamp/modules/site/memcached.php
+++ b/web/yaamp/modules/site/memcached.php
@@ -2,8 +2,7 @@
 
 echo "<a href='/site/memcached'>refresh</a><br>";
 
-$memcache = controller()->memcache->memcache;
-$a = memcache_get($this->memcache->memcache, 'url-map');
+$a = controller()->memcache->memcache->get( 'url-map');
 
 function printStats($stat)
 {
@@ -51,7 +50,7 @@ function cmp($a, $b)
 if (!empty($a))
 foreach($a as $url=>$n)
 {
-	$d = memcache_get($this->memcache->memcache, "$url-time");
+	$d = $this->memcache->get("$url-time");
 	$avg = $d/$n;
 
 	$res[] = array($url, $n, $d, $avg);


### PR DESCRIPTION
In few places `memcache_get` and `memcache_set` were still being used instead of the methods of the `YaampMemcache` object.