### PR TITLE
stratum: autoselect masternode rpc style

### DIFF
--- a/stratum/coinbase.cpp
+++ b/stratum/coinbase.cpp
@@ -212,9 +212,80 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 			}
 		}
 	}
+    
+    if(coind->hasmasternodes && json_get_bool(json_result, "masternode_payments")) /* OLD DASH style */
+	{
+		char charity_payee[256] = { 0 };
+		const char *payee = json_get_string(json_result, "payee");
+		if (payee) snprintf(charity_payee, 255, "%s", payee);
+
+		json_int_t charity_amount = json_get_int(json_result, "payee_amount");
+		bool charity_payments = json_get_bool(json_result, "masternode_payments");
+		bool charity_enforce = json_get_bool(json_result, "enforce_masternode_payments");
+
+		if(strcmp(coind->symbol, "CRW") == 0)
+		{
+			char script_dests[2048] = { 0 };
+			char script_payee[128] = { 0 };
+			char payees[4];
+			int npayees = 1;
+			bool masternodes_enabled = json_get_bool(json_result, "enforce_masternode_payments");
+			bool systemnodes_enabled = json_get_bool(json_result, "enforce_systemnode_payments");
+			bool systemnodes = json_get_bool(json_result, "systemnodes");
+			bool masternodes = json_get_bool(json_result, "masternodes");
+			if(systemnodes_enabled && systemnodes) {
+				const char *payeeSN = json_get_string(json_result, "payeeSN");
+				json_int_t payeeSN_amount = json_get_int(json_result, "payeeSN_amount");
+				if (payeeSN && payeeSN_amount) {
+					npayees++;
+					available -= payeeSN_amount;
+					base58_decode(payeeSN, script_payee);
+					job_pack_tx(coind, script_dests, payeeSN_amount, script_payee);
+					//debuglog("%s systemnode %s %u\n", coind->symbol, payeeSN, payeeSN_amount);
+				}
+			}
+			if (masternodes_enabled && masternodes) {
+				const char *payee = json_get_string(json_result, "payee");
+				json_int_t amount = json_get_int(json_result, "amount");
+				if (payee && amount) {
+					npayees++;
+					available -= amount;
+					base58_decode(payee, script_payee);
+					job_pack_tx(coind, script_dests, amount, script_payee);
+				}
+			}
+			sprintf(payees, "%02x", npayees);
+			strcat(templ->coinb2, payees);
+			strcat(templ->coinb2, script_dests);
+			job_pack_tx(coind, templ->coinb2, available, NULL);
+			strcat(templ->coinb2, "00000000"); // locktime
+			coind->reward = (double)available/100000000*coind->reward_mul;
+			//debuglog("%s %d dests %s\n", coind->symbol, npayees, script_dests);
+			return;
+		}
+
+		if(charity_payments && charity_enforce)
+		{
+			char script_payee[256] = { 0 };
+			base58_decode(charity_payee, script_payee);
+
+			if (templ->has_segwit_txs) {
+				strcat(templ->coinb2, "03"); // 3 outputs (nulldata + node + miner)
+				strcat(templ->coinb2, commitment);
+			} else {
+				strcat(templ->coinb2, "02"); // 2 outputs
+			}
+
+			job_pack_tx(coind, templ->coinb2, charity_amount, script_payee);
+			available -= charity_amount;
+
+		} else {
+			strcat(templ->coinb2, "01");
+		}
+	}
 
 	// most recent masternodes rpc (DASH, SIB, MUE, DSR, GBX...)
-	if(coind->hasmasternodes && !coind->oldmasternodes)
+	else if(coind->hasmasternodes)
 	{
 		char script_dests[2048] = { 0 };
 		char script_payee[128] = { 0 };
@@ -341,78 +412,6 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		coind->reward = (double)available/100000000*coind->reward_mul;
 		//debuglog("%s %d dests %s\n", coind->symbol, npayees, script_dests);
 		return;
-	}
-
-
-	else if(coind->hasmasternodes && coind->oldmasternodes) /* OLD DASH style */
-	{
-		char charity_payee[256] = { 0 };
-		const char *payee = json_get_string(json_result, "payee");
-		if (payee) snprintf(charity_payee, 255, "%s", payee);
-
-		json_int_t charity_amount = json_get_int(json_result, "payee_amount");
-		bool charity_payments = json_get_bool(json_result, "masternode_payments");
-		bool charity_enforce = json_get_bool(json_result, "enforce_masternode_payments");
-
-		if(strcmp(coind->symbol, "CRW") == 0)
-		{
-			char script_dests[2048] = { 0 };
-			char script_payee[128] = { 0 };
-			char payees[4];
-			int npayees = 1;
-			bool masternodes_enabled = json_get_bool(json_result, "enforce_masternode_payments");
-			bool systemnodes_enabled = json_get_bool(json_result, "enforce_systemnode_payments");
-			bool systemnodes = json_get_bool(json_result, "systemnodes");
-			bool masternodes = json_get_bool(json_result, "masternodes");
-			if(systemnodes_enabled && systemnodes) {
-				const char *payeeSN = json_get_string(json_result, "payeeSN");
-				json_int_t payeeSN_amount = json_get_int(json_result, "payeeSN_amount");
-				if (payeeSN && payeeSN_amount) {
-					npayees++;
-					available -= payeeSN_amount;
-					base58_decode(payeeSN, script_payee);
-					job_pack_tx(coind, script_dests, payeeSN_amount, script_payee);
-					//debuglog("%s systemnode %s %u\n", coind->symbol, payeeSN, payeeSN_amount);
-				}
-			}
-			if (masternodes_enabled && masternodes) {
-				const char *payee = json_get_string(json_result, "payee");
-				json_int_t amount = json_get_int(json_result, "amount");
-				if (payee && amount) {
-					npayees++;
-					available -= amount;
-					base58_decode(payee, script_payee);
-					job_pack_tx(coind, script_dests, amount, script_payee);
-				}
-			}
-			sprintf(payees, "%02x", npayees);
-			strcat(templ->coinb2, payees);
-			strcat(templ->coinb2, script_dests);
-			job_pack_tx(coind, templ->coinb2, available, NULL);
-			strcat(templ->coinb2, "00000000"); // locktime
-			coind->reward = (double)available/100000000*coind->reward_mul;
-			//debuglog("%s %d dests %s\n", coind->symbol, npayees, script_dests);
-			return;
-		}
-
-		if(charity_payments && charity_enforce)
-		{
-			char script_payee[256] = { 0 };
-			base58_decode(charity_payee, script_payee);
-
-			if (templ->has_segwit_txs) {
-				strcat(templ->coinb2, "03"); // 3 outputs (nulldata + node + miner)
-				strcat(templ->coinb2, commitment);
-			} else {
-				strcat(templ->coinb2, "02"); // 2 outputs
-			}
-
-			job_pack_tx(coind, templ->coinb2, charity_amount, script_payee);
-			available -= charity_amount;
-
-		} else {
-			strcat(templ->coinb2, "01");
-		}
 	}
 
 	else if (templ->has_segwit_txs) {

--- a/stratum/coind.h
+++ b/stratum/coind.h
@@ -65,7 +65,6 @@ public:
 	bool usegetwork;
 	bool usememorypool;
 	bool hasmasternodes;
-	bool oldmasternodes;
 	bool noblocknotify;
 	bool multialgos; // pow_hash field (or mined_hash)
 

--- a/stratum/db.cpp
+++ b/stratum/db.cpp
@@ -292,24 +292,6 @@ void db_update_coinds(YAAMP_DB *db)
 		if(!strcmp(coind->symbol, "DCR") && strcmp(coind->rpcencoding, "DCR"))
 			strcpy(coind->rpcencoding, "DCR");
 
-		// old dash masternodes coins..
-		if(coind->hasmasternodes) {
-			if (strcmp(coind->symbol, "ALQO") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "BSD") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "BWK") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "CHC") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "CRW") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "DNR") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "FLAX") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "ITZ") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "J") == 0 || strcmp(coind->symbol2, "J") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "MAG") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "PBS") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "URALS") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "VSX") == 0) coind->oldmasternodes = true;
-			if (strcmp(coind->symbol, "XLR") == 0) coind->oldmasternodes = true;
-		}
-
 		////////////////////////////////////////////////////////////////////////////////////////////////////
 
 		//coind->touch = true;


### PR DESCRIPTION
Problem: Annoying to check which masternode version it is, and to recompile stratum every time for an old one.
Solution: Check for "masternode_payments".

Tested with ALQO (oldmasternode) and EXUS (new masternode rpc)
Would like more tests run before merging