### PR TITLE
Make an usleep after blocknotify recieved to prevent loosing blocks

### DIFF
--- a/stratum/client.cpp
+++ b/stratum/client.cpp
@@ -313,7 +313,7 @@ bool client_update_block(YAAMP_CLIENT *client, json_value *json_params)
 	if (!strcmp("DCR", coind->rpcencoding)) {
 		usleep(300*YAAMP_MS);
 	} else {
-		sleep(1); // needed to prevent some cases when ACCEPT appears few ms after NOTIFY. TODO: make new block_confirm()
+		usleep(1000*YAAMP_MS); // needed to prevent some cases when ACCEPT appears few ms after NOTIFY. TODO: make new block_confirm(). You can play with this number for your system
 	}
 
 	block_confirm(coind->id, hash);

--- a/stratum/client.cpp
+++ b/stratum/client.cpp
@@ -312,6 +312,8 @@ bool client_update_block(YAAMP_CLIENT *client, json_value *json_params)
 
 	if (!strcmp("DCR", coind->rpcencoding)) {
 		usleep(300*YAAMP_MS);
+	} else {
+		sleep(1); // needed to prevent some cases when ACCEPT appears few ms after NOTIFY. TODO: make new block_confirm()
 	}
 
 	block_confirm(coind->id, hash);


### PR DESCRIPTION
Prevent cases when wallet answers "ACCEPT" blockhash few ms after "BLOCKNOTIFY" and block is not stored in db...

You can play with number of MS in usleep to get minimal delay in you system...

Real example from logs:
16:58:37: notify: new block ZZZZZZZZ
16:58:37: *** ACCEPTED (diff 12345) by XXXX
(names were changed :D )