### PR TITLE
stratum: Add STAK with SegWit support

### DIFF
--- a/stratum/coinbase.cpp
+++ b/stratum/coinbase.cpp
@@ -145,6 +145,68 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		if (strlen(coind->charity_address) == 0 && !strcmp(coind->symbol, "DCR"))
 			sprintf(coind->charity_address, "Dcur2mcGjmENx4DhNqDctW5wJCVyT3Qeqkx");
 	}
+	else if(strcmp(coind->symbol, "STAK") == 0) {
+		char script_dests[1024] = { 0 };
+		char script_payee[1024];
+		char payee_address[1024];
+		char payees[4];
+		int npayees = (templ->has_segwit_txs) ? 2 : 1;
+		bool masternode_payments = json_get_bool(json_result, "masternode_payments");
+		bool masternodes_enabled = json_get_bool(json_result, "enforce_masternode_payments");
+
+		if (masternodes_enabled && masternode_payments) {
+			const char *payee = json_get_string(json_result, "payee");
+			json_int_t amount = json_get_int(json_result, "payee_amount");
+			if (payee && amount)
+				++npayees;
+		}
+		
+		//treasury 5% @ 10 STAK per block
+		json_int_t charity_amount = 50000000;
+		//testnet
+		//sprintf(coind->charity_address, "93ASJtDuVYVdKXemH9BrtSMscznvsp9stD");  
+		switch (templ->height % 4) {
+			case 0: sprintf(coind->charity_address, "3K3bPrW5h7DYEMp2RcXawTCXajcm4ZU9Zh");
+			break;
+			case 1: sprintf(coind->charity_address, "33Ssxmn3ehVMgyxgegXhpLGSBpubPjLZQ6");
+			break;
+			case 2: sprintf(coind->charity_address, "3HFPNAjesiBY5sSVUmuBFnMEGut69R49ca");
+			break;
+			case 3: sprintf(coind->charity_address, "37jLjjfUXQU4bdqVzvpUXyzAqPQSmxyByi");
+			break;
+		}
+		++npayees;
+		available -= charity_amount;
+		strcpy(payee_address, coind->charity_address);
+		base58_decode(payee_address, script_payee);
+		sprintf(payees, "%02x", npayees);
+		strcat(templ->coinb2, payees);
+		if (templ->has_segwit_txs) strcat(templ->coinb2, commitment);
+		char echarity_amount[32];
+		encode_tx_value(echarity_amount, charity_amount);
+		strcat(templ->coinb2, echarity_amount);
+		char coinb2_part[1024] = { 0 };
+		char coinb2_len[3] = { 0 };
+		sprintf(coinb2_part, "a9%02x%s87", (unsigned int)(strlen(script_payee) >> 1) & 0xFF, script_payee);
+		sprintf(coinb2_len, "%02x", (unsigned int)(strlen(coinb2_part) >> 1) & 0xFF);
+		strcat(templ->coinb2, coinb2_len);
+		strcat(templ->coinb2, coinb2_part);
+		if (masternodes_enabled && masternode_payments) {
+			//duplicated: revisit ++todo
+			const char *payee = json_get_string(json_result, "payee");
+			json_int_t amount = json_get_int(json_result, "payee_amount");
+			if (payee && amount) {
+				available -= amount;
+				base58_decode(payee, script_payee);
+				job_pack_tx(coind, templ->coinb2, amount, script_payee);
+			}
+		}
+		job_pack_tx(coind, templ->coinb2, available, NULL);
+		strcat(templ->coinb2, "00000000"); // locktime
+
+		coind->reward = (double)available / 100000000 * coind->reward_mul;
+		return;		
+	}
 
 	// 2 txs are required on these coins, one for foundation (dev fees)
 	if(coind->charity_percent)


### PR DESCRIPTION
Incorporates STRAKS (STAK) coin with the following inclusions;

- Masternodes
- Treasury Payments
- SegWit

Testnet Proof - https://testnet.straks.info/en/block/0000000d5c260d8d7219587e3eebb2a0009bee2ca9e5b662e80ab85c6464f4d5