### PR TITLE
Fix payout race condition

### DIFF
--- a/web/yaamp/core/backend/payment.php
+++ b/web/yaamp/core/backend/payment.php
@@ -167,22 +167,23 @@ function BackendCoinPayments($coin)
 	$payouts = array();
 	foreach($users as $user)
 	{
-		$user = getdbo('db_accounts', $user->id);
 		if(!$user) continue;
 		if(!isset($addresses[$user->username])) continue;
+
+		$payment_amount = $addresses[$user->username];
 
 		$payout = new db_payouts;
 		$payout->account_id = $user->id;
 		$payout->time = time();
-		$payout->amount = bitcoinvaluetoa($user->balance*$coef);
+		$payout->amount = bitcoinvaluetoa($payment_amount*$coef);
 		$payout->fee = 0;
 		$payout->idcoin = $coin->id;
 
 		if ($payout->save()) {
 			$payouts[$payout->id] = $user->id;
+			$payout_after_coefficient = bitcoinvaluetoa(floatval($payment_amount)*$coef);
 
-			$user->balance = bitcoinvaluetoa(floatval($user->balance) - (floatval($user->balance)*$coef));
-			$user->save();
+			dborun("UPDATE accounts SET balance = balance - :amt WHERE id=:uid", array(':amt'=>$payout_after_coefficient, ':uid'=>$user->id));
 		}
 	}
 

--- a/web/yaamp/core/backend/payment.php
+++ b/web/yaamp/core/backend/payment.php
@@ -170,20 +170,19 @@ function BackendCoinPayments($coin)
 		if(!$user) continue;
 		if(!isset($addresses[$user->username])) continue;
 
-		$payment_amount = $addresses[$user->username];
+		$payment_amount = bitcoinvaluetoa($addresses[$user->username]);
 
 		$payout = new db_payouts;
 		$payout->account_id = $user->id;
 		$payout->time = time();
-		$payout->amount = bitcoinvaluetoa($payment_amount*$coef);
+		$payout->amount = $payment_amount;
 		$payout->fee = 0;
 		$payout->idcoin = $coin->id;
 
 		if ($payout->save()) {
 			$payouts[$payout->id] = $user->id;
-			$payout_after_coefficient = bitcoinvaluetoa(floatval($payment_amount)*$coef);
 
-			dborun("UPDATE accounts SET balance = balance - :amt WHERE id=:uid", array(':amt'=>$payout_after_coefficient, ':uid'=>$user->id));
+			dborun("UPDATE accounts SET balance = balance - :amt WHERE id=:uid", array(':amt'=>$payment_amount, ':uid'=>$user->id));
 		}
 	}
 


### PR DESCRIPTION
The payments function pulls the `$user` object from the database twice and computes blockchain payments based on one and creates database objects based on the other. Since these operations are not transactional, it is necessary to use a consistent value, e.g. the one that already exists in the `$addresses` associative array.