### PR TITLE
market: handle graviex ticker

### DIFF
--- a/web/yaamp/core/backend/markets.php
+++ b/web/yaamp/core/backend/markets.php
@@ -14,6 +14,7 @@ function BackendPricesUpdate()
 	updatePoloniexMarkets();
 	updateBleutradeMarkets();
 	updateCryptoBridgeMarkets();
+    updateGraviexMarkets();
 	updateKrakenMarkets();
 	updateKuCoinMarkets();
 	updateCCexMarkets();
@@ -327,6 +328,52 @@ function updateCryptoBridgeMarkets($force = false)
 		$market->save();
 
 		//debuglog("$exchange: update $symbol: {$market->price} {$market->price2}");
+	}
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+function updateGraviexMarkets($force = false)
+{
+	$exchange = 'graviex';
+	if (exchange_get($exchange, 'disabled')) return;
+
+	$list = getdbolist('db_markets', "name LIKE '$exchange%'");
+	if (empty($list)) return;
+
+	$markets = graviex_api_query('tickers');
+	if(!is_array($markets)) return;
+
+	foreach($list as $market)
+	{
+		$coin = getdbo('db_coins', $market->coinid);
+		if(!$coin) continue;
+        
+		$symbol = $coin->getOfficialSymbol();
+		if (market_get($exchange, $symbol, "disabled")) {
+			$market->disabled = 1;
+			$market->message = 'disabled from settings';
+			$market->save();
+			continue;
+		}
+
+        $symbol = strtolower($symbol);        
+		$dbpair = $symbol.'btc';
+		foreach ($markets as $pair => $ticker) {
+			if ($pair != $dbpair) continue;
+			$price2 = ($ticker['ticker']['high']+$ticker['ticker']['low'])/2;
+			$market->price = AverageIncrement($market->price, $ticker['ticker']['high']);
+			$market->price2 = AverageIncrement($market->price2, $price2);
+			$market->pricetime = time();
+			$market->save();
+
+			if (empty($coin->price2)) {
+				$coin->price = $market->price;
+				$coin->price2 = $market->price2;
+				$coin->market = $exchange;
+				$coin->save();
+			}
+		}
 	}
 }
 

--- a/web/yaamp/core/backend/markets.php
+++ b/web/yaamp/core/backend/markets.php
@@ -14,7 +14,7 @@ function BackendPricesUpdate()
 	updatePoloniexMarkets();
 	updateBleutradeMarkets();
 	updateCryptoBridgeMarkets();
-    updateGraviexMarkets();
+	updateGraviexMarkets();
 	updateKrakenMarkets();
 	updateKuCoinMarkets();
 	updateCCexMarkets();

--- a/web/yaamp/core/backend/markets.php
+++ b/web/yaamp/core/backend/markets.php
@@ -357,7 +357,7 @@ function updateGraviexMarkets($force = false)
 			continue;
 		}
 
-        $symbol = strtolower($symbol);        
+		$symbol = strtolower($symbol);        
 		$dbpair = $symbol.'btc';
 		foreach ($markets as $pair => $ticker) {
 			if ($pair != $dbpair) continue;

--- a/web/yaamp/core/exchange/exchange.php
+++ b/web/yaamp/core/exchange/exchange.php
@@ -105,7 +105,7 @@ function getMarketUrl($coin, $marketName)
 		$url = "https://c-cex.com/?p={$lowsymbol}-{$lowbase}";
 	else if($market == 'empoex')
 		$url = "http://www.empoex.com/trade/{$symbol}-{$base}";
-    else if($market == 'graviex')
+	else if($market == 'graviex')
 		$url = "https://graviex.net/api/v2/tickers/{$symbol}{$base}";
 	else if($market == 'jubi')
 		$url = "http://jubi.com/coin/{$lowsymbol}";

--- a/web/yaamp/core/exchange/exchange.php
+++ b/web/yaamp/core/exchange/exchange.php
@@ -19,6 +19,7 @@ require_once("bleutrade.php");
 require_once("ccexapi.php");
 require_once("cexio.php");
 require_once("cryptobridge.php");
+require_once("graviex.php");
 require_once("cryptohub.php");
 require_once("kraken.php");
 require_once("poloniex.php");
@@ -104,6 +105,8 @@ function getMarketUrl($coin, $marketName)
 		$url = "https://c-cex.com/?p={$lowsymbol}-{$lowbase}";
 	else if($market == 'empoex')
 		$url = "http://www.empoex.com/trade/{$symbol}-{$base}";
+    else if($market == 'graviex')
+		$url = "https://graviex.net/api/v2/tickers/{$symbol}{$base}";
 	else if($market == 'jubi')
 		$url = "http://jubi.com/coin/{$lowsymbol}";
 	else if($market == 'hitbtc')

--- a/web/yaamp/core/exchange/graviex.php
+++ b/web/yaamp/core/exchange/graviex.php
@@ -1,0 +1,23 @@
+<?php
+
+// https://graviex.net/api/v2/tickers.json
+
+function graviex_api_query($method, $params='')
+{
+	$uri = "https://graviex.net/api/v2/{$method}";
+	if (!empty($params)) $uri .= "/{$params}";
+
+	$ch = curl_init($uri);
+	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+	curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+
+	$execResult = strip_tags(curl_exec($ch));
+    
+    // array required for ticker "foreach"
+	$obj = json_decode($execResult, true);
+
+	return $obj;
+}
+

--- a/web/yaamp/core/exchange/graviex.php
+++ b/web/yaamp/core/exchange/graviex.php
@@ -11,11 +11,11 @@ function graviex_api_query($method, $params='')
 	curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 	curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 	curl_setopt($ch, CURLOPT_TIMEOUT, 30);
-    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
 	$execResult = strip_tags(curl_exec($ch));
     
-    // array required for ticker "foreach"
+	// array required for ticker "foreach"
 	$obj = json_decode($execResult, true);
 
 	return $obj;


### PR DESCRIPTION
Implemented very similarly to cryptohub.
Note: graviex ssl is improper, so 
`curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);`
was needed. May be possible to remove in the future.