### PR TITLE
quark: change estimates in mBTC/GH like other sha algos

### DIFF
--- a/web/yaamp/core/functions/yaamp.php
+++ b/web/yaamp/core/functions/yaamp.php
@@ -80,6 +80,7 @@ function yaamp_algo_mBTC_factor($algo)
 	case 'keccak':
 	case 'keccakc':
 	case 'lbry':
+	case 'quark':
 	case 'vanilla':
 		return 1000;
 	default:


### PR DESCRIPTION
NH buyers asked unimining and antminepool to do this change, aim is to see more decimals for calculations

if needed (already mining) you can do that to update the pool estimate graph values:
UPDATE hashrate SET price=price*1000.0, rent=rent*1000 WHERE algo='quark' AND price < 0.01;