### PR TITLE
markets: fix graviex market url

### DIFF
--- a/web/yaamp/core/exchange/exchange.php
+++ b/web/yaamp/core/exchange/exchange.php
@@ -106,7 +106,7 @@ function getMarketUrl($coin, $marketName)
 	else if($market == 'empoex')
 		$url = "http://www.empoex.com/trade/{$symbol}-{$base}";
 	else if($market == 'graviex')
-		$url = "https://graviex.net/api/v2/tickers/{$symbol}{$base}";
+		$url = "https://graviex.net/markets/{$lowsymbol}{$lowbase}";
 	else if($market == 'jubi')
 		$url = "http://jubi.com/coin/{$lowsymbol}";
 	else if($market == 'hitbtc')


### PR DESCRIPTION
Fixes the url of the market in /site/coin?id=?
I apologize that I missed this the first time around.