### PR TITLE
Added support for Machinecoin 0.16.0

### DIFF
--- a/stratum/coinbase.cpp
+++ b/stratum/coinbase.cpp
@@ -204,6 +204,71 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		coind->reward = (double)available / 100000000 * coind->reward_mul;
 		return;
 	}
+ 	else if(strcmp(coind->symbol, "MAC") == 0) {
+		char script_payee[1024] = { 0 };
+		char payees[4];
+		int npayees = (templ->has_segwit_txs) ? 2 : 1;
+		bool masternode_enabled = json_get_bool(json_result, "masternode_payments_enforced");
+		bool superblocks_enabled = json_get_bool(json_result, "superblocks_enabled");
+		json_value* superblock = json_get_array(json_result, "superblock");
+		json_value* masternode = json_get_object(json_result, "masternode");
+
+		if (masternode_enabled && masternode) {
+			const char *payee = json_get_string(masternode, "payee");
+			json_int_t amount = json_get_int(masternode, "amount");
+			if (payee && amount)
+				++npayees;
+		}
+  		if(superblocks_enabled && superblock) {
+			for(int i = 0; i < superblock->u.array.length; i++) {
+				const char *payee = json_get_string(superblock->u.array.values[i], "payee");
+				json_int_t amount = json_get_int(superblock->u.array.values[i], "amount");
+				if (payee && amount) {
+					++npayees;
+				}
+			}
+		}
+		sprintf(payees, "%02x", npayees);
+		strcat(templ->coinb2, payees);
+		if (templ->has_segwit_txs) strcat(templ->coinb2, commitment);
+  		if(superblocks_enabled && superblock) {
+			for(int i = 0; i < superblock->u.array.length; i++) {
+				const char *payee = json_get_string(superblock->u.array.values[i], "payee");
+				json_int_t amount = json_get_int(superblock->u.array.values[i], "amount");
+				if (payee && amount) {
+					npayees++;
+					available -= amount;
+     					// superblock payments are going to use P2SH addresses / segwit transactions
+					base58_decode(payee, script_payee);
+					char eamount[32];
+					encode_tx_value(eamount, amount);
+					strcat(templ->coinb2, eamount);
+					char coinb2_part[1024] = { 0 };
+					char coinb2_len[3] = { 0 };
+					sprintf(coinb2_part, "a9%02x%s87", (unsigned int)(strlen(script_payee) >> 1) & 0xFF, script_payee);
+					sprintf(coinb2_len, "%02x", (unsigned int)(strlen(coinb2_part) >> 1) & 0xFF);
+					strcat(templ->coinb2, coinb2_len);
+					strcat(templ->coinb2, coinb2_part);
+					debuglog("%s superblock %s %u\n", coind->symbol, payee, amount);
+				}
+			}
+		}
+		if (masternode_enabled && masternode) {
+			const char *payee = json_get_string(masternode, "payee");
+			json_int_t amount = json_get_int(masternode, "amount");
+			if (payee && amount) {
+				npayees++;
+				available -= amount;
+				base58_decode(payee, script_payee);
+				job_pack_tx(coind, templ->coinb2, amount, script_payee);
+			}
+		}
+		job_pack_tx(coind, templ->coinb2, available, NULL);
+		strcat(templ->coinb2, "00000000"); // locktime
+
+		coind->reward = (double)available / 100000000 * coind->reward_mul;
+		return;
+	}
 
 	// 2 txs are required on these coins, one for foundation (dev fees)
 	if(coind->charity_percent)


### PR DESCRIPTION
Hey there,

Machinecoin Core 0.16.0 is ready to release, and will be available within the next days and take affect within in 7-8 days.
The release will include masternodes, aswell as superblocks.
Also, P2SH will be the default address type.

MN are going to use legacy addresses.
Superblocks are going to use P2SH addresses.

This code should provide a fix for problems detected before during testing.

Ref. Pull: #264

-Nico;