### PR TITLE
Support for MAC P2SH masternodes

### DIFF
--- a/stratum/coinbase.cpp
+++ b/stratum/coinbase.cpp
@@ -321,7 +321,20 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 				npayees++;
 				available -= amount;
 				base58_decode(payee, script_payee);
-				job_pack_tx(coind, script_dests, amount, script_payee);
+				bool masternode_use_p2sh = (strcmp(coind->symbol, "MAC") == 0);
+				if(masternode_use_p2sh) {
+					char eamount[32] = { 0 };
+					char coinb2_part[256];
+					char coinb2_len[4];
+					sprintf(coinb2_part, "a9%02x%s87", (unsigned int)(strlen(script_payee) >> 1) & 0xFF, script_payee);
+					sprintf(coinb2_len, "%02x", (unsigned int)(strlen(coinb2_part) >> 1) & 0xFF);
+					encode_tx_value(eamount, amount);
+					strcat(script_dests, eamount);
+					strcat(script_dests, coinb2_len);
+					strcat(script_dests, coinb2_part);
+				} else {
+					job_pack_tx(coind, script_dests, amount, script_payee);
+				}
 			}
 		}
 		sprintf(payees, "%02x", npayees);


### PR DESCRIPTION
MAC is going to use P2SH addresses for masternodes as of version 0.16.
This code should provide support for them.

Nico;