### PR TITLE
yaamp: fix don't send coins to exchange which have late tx already

### DIFF
--- a/web/yaamp/core/backend/sell.php
+++ b/web/yaamp/core/backend/sell.php
@@ -38,7 +38,7 @@ function sellCoinToExchange($coin)
 	$market = getBestMarket($coin);
 	if(!$market) return;
 
-	if(!$coin->sellonbid && $market->lastsent != null && $market->lastsent > $market->lasttraded)
+	if($market->lastsent != null && $market->lastsent > $market->lasttraded)
 	{
 //		debuglog("*** not sending $coin->name to $market->name. last tx is late ***");
 		return;
@@ -77,9 +77,6 @@ function sellCoinToExchange($coin)
 	$amount = round($amount, 8);
 //	debuglog("sending $amount $coin->symbol to $marketname, $deposit_address");
 
-	$market->lastsent = time();
-	$market->save();
-
 //	sleep(1);
 
 	$tx = $remote->sendtoaddress($deposit_address, $amount);
@@ -106,6 +103,12 @@ function sellCoinToExchange($coin)
 			debuglog($remote->error);
 			return;
 		}
+	}
+	
+		if ($tx)
+	{
+		$market->lastsent = time();
+		$market->save();
 	}
 
 	$exchange = new db_exchange;


### PR DESCRIPTION
All coins including ones with sell on bid shouldn't send to exchanges with late transactions.
Update lastsent after a valid transaction not before.