### PR TITLE
Site wallet : disable deletion of current wallet

### DIFF
--- a/web/yaamp/modules/site/wallet.php
+++ b/web/yaamp/modules/site/wallet.php
@@ -141,9 +141,10 @@ foreach($recents as $addr)
 		$balance = $balance>0? "$balance BTC": '';
 
 	echo '<td align="right">'.$balance.'</td>';
-	echo '<td style="width: 16px; max-width: 16px;">'.
-		'<img src="/images/base/delete.png" onclick="javascript:drop_cookie(this);" style="cursor:pointer;"/>'.
-	'</td>';
+	
+	$delicon = $address == $addr ? '' : '<img src="/images/base/delete.png" onclick="javascript:drop_cookie(this);" style="cursor:pointer;"/>';
+	echo '<td style="width: 16px; max-width: 16px;">'.$delicon.'</td>';
+	
 	echo '</tr>';
 }
 


### PR DESCRIPTION
Couldn't figure out why I couldn't delete an address in wallet page when I realized it was current address.
This little change should prevent users to try it.

Sorry if my php isn't good (ten years without practice)