### PR TITLE
Avoid unnecessary coind objects creation

### DIFF
--- a/stratum/db.cpp
+++ b/stratum/db.cpp
@@ -207,6 +207,8 @@ void db_update_coinds(YAAMP_DB *db)
 		YAAMP_COIND *coind = (YAAMP_COIND *)object_find(&g_list_coind, atoi(row[0]));
 		if(!coind)
 		{
+		   if (!strlen(g_stratum_coin_include) || (strlen(g_stratum_coin_include) && strstr(g_stratum_coin_include, row[20])))
+		   {
 			coind = new YAAMP_COIND;
 			memset(coind, 0, sizeof(YAAMP_COIND));
 
@@ -214,6 +216,9 @@ void db_update_coinds(YAAMP_DB *db)
 			coind->newblock = true;
 			coind->id = atoi(row[0]);
 			coind->aux.coind = coind;
+		   }
+		   else
+			continue;
 		}
 		else
 			coind->newcoind = false;


### PR DESCRIPTION
Solution against stratum memory leak for dedicated (port per coin) stratum usage, when used 'include' option in stratum config.