### PR TITLE
added MCT to coins having an issue with sendmany

### DIFF
--- a/web/yaamp/core/backend/payment.php
+++ b/web/yaamp/core/backend/payment.php
@@ -54,7 +54,7 @@ function BackendCoinPayments($coin)
 	$users = getdbolist('db_accounts', "balance>$min_payout AND coinid={$coin->id} ORDER BY balance DESC");
 
 	// todo: enhance/detect payout_max from normal sendmany error
-	if($coin->symbol == 'BOD' || $coin->symbol == 'DIME' || $coin->symbol == 'BTCRY' || !empty($coin->payout_max))
+	if($coin->symbol == 'BOD' || $coin->symbol == 'DIME' || $coin->symbol == 'BTCRY' || $coin->symbol == 'MCT' || !empty($coin->payout_max))
 	{
 		foreach($users as $user)
 		{


### PR DESCRIPTION
fixes this error:
sendmany: unable to send 24.75005533 error -1: json value is not a boolean as expected {"MSxxxxxxxxxxx":24.75005533}