### PR TITLE
Lightning Network (testnet)

### DIFF
--- a/rc.local
+++ b/rc.local
@@ -15,6 +15,7 @@ STRATUM_DIR=/var/stratum
 screen -dmS main $WEB_DIR/main.sh
 screen -dmS loop2 $WEB_DIR/loop2.sh
 screen -dmS blocks $WEB_DIR/blocks.sh
+#screen -dmS ln $WEB_DIR/ln.sh
 screen -dmS debug tail -f $LOG_DIR/debug.log
 
 # Stratum instances (skipped/exit if no .conf)

--- a/sql/2018-08-lightning-testnet.sql
+++ b/sql/2018-08-lightning-testnet.sql
@@ -1,6 +1,7 @@
 CREATE TABLE `invoices` (
   `id` int(11) NOT NULL,
   `userid` int(11) NOT NULL,
+  `workerid` int(11) NOT NULL,
   `bolt11` varchar(1000) NOT NULL,
   `amount` int(11) NOT NULL,
   `paid` int(11) NOT NULL,

--- a/sql/2018-08-lightning-testnet.sql
+++ b/sql/2018-08-lightning-testnet.sql
@@ -1,5 +1,6 @@
 CREATE TABLE `invoices` (
   `id` int(11) NOT NULL,
+  `userid` int(11) NOT NULL,
   `bolt11` varchar(1000) NOT NULL,
   `amount` int(11) NOT NULL,
   `paid` int(11) NOT NULL,

--- a/sql/2018-08-lightning-testnet.sql
+++ b/sql/2018-08-lightning-testnet.sql
@@ -8,3 +8,5 @@ CREATE TABLE `invoices` (
   `status` varchar(80) DEFAULT NULL,
   `exectime` int(10) UNSIGNED NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+ALTER TABLE `workers` ADD `work` DOUBLE NOT NULL DEFAULT '0.0' AFTER `algo`;

--- a/sql/2018-08-lightning-testnet.sql
+++ b/sql/2018-08-lightning-testnet.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `invoices` (
+  `id` int(11) NOT NULL,
+  `bolt11` varchar(1000) NOT NULL,
+  `amount` int(11) NOT NULL,
+  `paid` int(11) NOT NULL,
+  `shop` text,
+  `description` text NOT NULL,
+  `status` varchar(80) DEFAULT NULL,
+  `exectime` int(10) UNSIGNED NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/web/ln.sh
+++ b/web/ln.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+PHP_CLI='php -d max_execution_time=60'
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd ${DIR}
+
+date
+echo started in ${DIR}
+
+while true; do
+        ${PHP_CLI} runconsole.php cronjob/runLightning
+        sleep 20
+done
+exec bash

--- a/web/yaamp/core/backend/blocks.php
+++ b/web/yaamp/core/backend/blocks.php
@@ -61,6 +61,12 @@ function BackendBlockNew($coin, $db_block)
 		$user->save();
 	}
 
+	$target = yaamp_hashrate_constant($coin->algo);
+	$interval = yaamp_hashrate_step();
+	$delay = time()-$interval;
+	
+	dborun("UPDATE workers w SET work = w.work + (SELECT (sum(difficulty) * $target / $interval / 1000) FROM shares WHERE valid AND time>".time()-$interval." AND workerid=w.id)");
+	
 	$delay = time() - 5*60;
 	$sqlCond = "time < $delay";
 	if(!YAAMP_ALLOW_EXCHANGE) // only one coin mined

--- a/web/yaamp/core/backend/payment.php
+++ b/web/yaamp/core/backend/payment.php
@@ -114,7 +114,7 @@ function BackendCoinPayments($coin)
 	{
 		$total_to_pay += round($user->balance, 8);
 		$addresses[$user->username] = round($user->balance, 8);
-		if ($coin->symbol=='BTC' && LN_ENABLED == true && YAAMP_LN_WORKERS == true)	{
+		if ($coin->symbol==LN_COIN && LN_ENABLED == true && YAAMP_LN_WORKERS == true)	{
 			$ln_works = getdbolist('db_workers', "work > 0 AND worker <> '' AND userid=".$user->id);
 			foreach($ln_works as $ln_work)	{
 				if (is_ln_invoice($ln_work->worker))	{

--- a/web/yaamp/core/backend/payment.php
+++ b/web/yaamp/core/backend/payment.php
@@ -32,6 +32,14 @@ function BackendUserCancelFailedPayment($userid)
 	return 0.0;
 }
 
+function is_ln_invoice($bill)
+{
+if (!empty($bill) && preg_match('/[^A-Za-z0-9]/', $bill))
+	return false;
+else
+	return true; // TODO: Enhance the check of the bolt11 invoice (length, first characters, ...)
+}
+
 function BackendCoinPayments($coin)
 {
 //	debuglog("BackendCoinPayments $coin->symbol");
@@ -106,6 +114,34 @@ function BackendCoinPayments($coin)
 	{
 		$total_to_pay += round($user->balance, 8);
 		$addresses[$user->username] = round($user->balance, 8);
+		if ($coin->symbol=='BTC' && YAAMP_LN_WORKERS == true)	{
+			$ln_works = getdbolist('db_workers', "work > 0 AND worker <> '' AND userid=".$user->id);
+			foreach($ln_works as $ln_work)	{
+				if (is_ln_invoice($ln_work->worker))	{
+                                        $output = shell_exec('sudo lightning-cli -J decodepay '.$ln_work->worker);
+                                        $bill = json_decode($output);
+                                        // TODO: Enhance and add pool fee
+					if ($ln_work->work * YAAMP_LN_FACTOR > $bill->msatoshi / 1000 && $user->balance > $bill->msatoshi / 1000)	{
+						$db_bill = getdbosql('db_invoices', "bolt11=:bolt11", array(':bolt11'=>$ln_work->worker));
+						if (!$db_bill)  {
+							dborun("INSERT IGNORE INTO invoices(bolt11, status) VALUES (:key,:val)", array(
+								':key'=>$bill,':val'=>"New"
+								));
+						}
+						if ($db_bill && $db_bill->status == "complete")	 {
+							// Invoice is already paid, no need to change total_to_pay and addresses
+						}
+						else	{
+							// Invoice is not paid yet: some value should be kept to pay it
+							// TODO: Add pool fee
+							$total_to_pay -= round($bill->msatoshi / 1000, 8);
+							$addresses[$user->username] -= round($bill->msatoshi / 1000, 8);
+						}
+					}
+				}
+			}
+		}
+		
 		// transaction xxx has too many sigops: 1035 > 1000
 		if ($coin->symbol == 'DCR' && count($addresses) > 990) {
 			debuglog("payment: more than 990 {$coin->symbol} users to pay, limit to top balances...");

--- a/web/yaamp/core/backend/payment.php
+++ b/web/yaamp/core/backend/payment.php
@@ -114,7 +114,7 @@ function BackendCoinPayments($coin)
 	{
 		$total_to_pay += round($user->balance, 8);
 		$addresses[$user->username] = round($user->balance, 8);
-		if ($coin->symbol=='BTC' && YAAMP_LN_WORKERS == true)	{
+		if ($coin->symbol=='BTC' && LN_ENABLED == true && YAAMP_LN_WORKERS == true)	{
 			$ln_works = getdbolist('db_workers', "work > 0 AND worker <> '' AND userid=".$user->id);
 			foreach($ln_works as $ln_work)	{
 				if (is_ln_invoice($ln_work->worker))	{

--- a/web/yaamp/defaultconfig.php
+++ b/web/yaamp/defaultconfig.php
@@ -85,6 +85,10 @@ if (!define('YAAMP_LN_WORKERS')) define('YAAMP_LN_WORKERS', false);
 if (!define('YAAMP_LN_FACTOR')) define('YAAMP_LN_FACTOR', 0.8);
 
 if (!isset($configLNGamePlayers)) $configLNGamePlayers = array (
+        /*
+        // testnet:
         'testnet.millionbitcoinhomepage.net' => array('023bcc1daeb7c85208991e993a2eacf86f7d9584a6dc33291bbe5e19c986a31568', '51.15.250.152', '9735'),
         'yalls.org' => array('02212d3ec887188b284dbb7b2e6eb40629a6e14fb049673f22d2a0aa05f902090e', '54.236.55.50', '9735'),
-        'testnet.satoshis.place' => array('02dd4cef0192611bc34cd1c3a0a7eb0f381e7229aa3309ae961a7fc0076b4d2bb6', '35.198.136.5', '9735'));
+        'testnet.satoshis.place' => array('02dd4cef0192611bc34cd1c3a0a7eb0f381e7229aa3309ae961a7fc0076b4d2bb6', '35.198.136.5', '9735')
+        */
+        );

--- a/web/yaamp/defaultconfig.php
+++ b/web/yaamp/defaultconfig.php
@@ -74,11 +74,15 @@ if (!defined('YIIMP_CLI_ALLOW_TXS')) define('YIIMP_CLI_ALLOW_TXS', false);
 
 // Lightning Network
 if (!defined('LN_ENABLED')) define('LN_ENABLED', false);
-if (!defined('LN_ENABLED')) define('LN_MY_BTC_ADDRESS', '');
-if (!defined('LN_ENABLED')) define('LN_MY_LN_ADDRESS', '');
-if (!defined('LN_ENABLED')) define('LN_MY_IP', '');
-if (!defined('LN_ENABLED')) define('LN_MY_PORT', '9735');
-if (!defined('LN_ENABLED')) define('LN_FRACTION', 7); // Fraction of main BTC wallet to fund channels
-if (!defined('LN_ENABLED')) define('LN_MIN_PAY', 3000);
-if (!defined('LN_ENABLED')) define('LN_MIN_PAY', 10000);
+if (!defined('LN_MY_BTC_ADDRESS')) define('LN_MY_BTC_ADDRESS', '');
+if (!defined('LN_MY_LN_ADDRESS')) define('LN_MY_LN_ADDRESS', '');
+if (!defined('LN_MY_IP')) define('LN_MY_IP', '');
+if (!defined('LN_MY_PORT')) define('LN_MY_PORT', '9735');
+if (!defined('LN_FRACTION')) define('LN_FRACTION', 7); // Fraction of main BTC wallet to fund channels
+if (!defined('LN_MIN_PAY')) define('LN_MIN_PAY', 3000);
+if (!defined('LN_MAIN_NODE')) define('LN_MAIN_NODE', '');
 
+if (!isset($configLNGamePlayers)) $configLNGamePlayers = array (
+        'testnet.millionbitcoinhomepage.net' => array('023bcc1daeb7c85208991e993a2eacf86f7d9584a6dc33291bbe5e19c986a31568', '51.15.250.152', '9735'),
+        'yalls.org' => array('02212d3ec887188b284dbb7b2e6eb40629a6e14fb049673f22d2a0aa05f902090e', '54.236.55.50', '9735'),
+        'testnet.satoshis.place' => array('02dd4cef0192611bc34cd1c3a0a7eb0f381e7229aa3309ae961a7fc0076b4d2bb6', '35.198.136.5', '9735'));

--- a/web/yaamp/defaultconfig.php
+++ b/web/yaamp/defaultconfig.php
@@ -81,6 +81,7 @@ if (!defined('LN_MY_PORT')) define('LN_MY_PORT', '9735');
 if (!defined('LN_FRACTION')) define('LN_FRACTION', 7); // Fraction of main BTC wallet to fund channels
 if (!defined('LN_MIN_PAY')) define('LN_MIN_PAY', 3000);
 if (!defined('LN_MAIN_NODE')) define('LN_MAIN_NODE', '');
+if (!define('YAAMP_LN_NET')) define('YAAMP_LN_NET', 'TESTNET'); // TESTNET or MAINET
 if (!define('YAAMP_LN_WORKERS')) define('YAAMP_LN_WORKERS', false);
 if (!define('YAAMP_LN_FACTOR')) define('YAAMP_LN_FACTOR', 0.8);
 

--- a/web/yaamp/defaultconfig.php
+++ b/web/yaamp/defaultconfig.php
@@ -76,6 +76,7 @@ if (!defined('YIIMP_CLI_ALLOW_TXS')) define('YIIMP_CLI_ALLOW_TXS', false);
 if (!defined('LN_ENABLED')) define('LN_ENABLED', false);
 if (!defined('LN_MY_BTC_ADDRESS')) define('LN_MY_BTC_ADDRESS', '');
 if (!defined('LN_MY_LN_ADDRESS')) define('LN_MY_LN_ADDRESS', '');
+if (!defined('LN_COIN')) define('LN_COIN', 'BTC');
 if (!defined('LN_MY_IP')) define('LN_MY_IP', '');
 if (!defined('LN_MY_PORT')) define('LN_MY_PORT', '9735');
 if (!defined('LN_FRACTION')) define('LN_FRACTION', 7); // Fraction of main BTC wallet to fund channels

--- a/web/yaamp/defaultconfig.php
+++ b/web/yaamp/defaultconfig.php
@@ -81,6 +81,8 @@ if (!defined('LN_MY_PORT')) define('LN_MY_PORT', '9735');
 if (!defined('LN_FRACTION')) define('LN_FRACTION', 7); // Fraction of main BTC wallet to fund channels
 if (!defined('LN_MIN_PAY')) define('LN_MIN_PAY', 3000);
 if (!defined('LN_MAIN_NODE')) define('LN_MAIN_NODE', '');
+if (!define('YAAMP_LN_WORKERS')) define('YAAMP_LN_WORKERS', false);
+if (!define('YAAMP_LN_FACTOR')) define('YAAMP_LN_FACTOR', 0.8);
 
 if (!isset($configLNGamePlayers)) $configLNGamePlayers = array (
         'testnet.millionbitcoinhomepage.net' => array('023bcc1daeb7c85208991e993a2eacf86f7d9584a6dc33291bbe5e19c986a31568', '51.15.250.152', '9735'),

--- a/web/yaamp/defaultconfig.php
+++ b/web/yaamp/defaultconfig.php
@@ -79,7 +79,7 @@ if (!defined('LN_MY_LN_ADDRESS')) define('LN_MY_LN_ADDRESS', '');
 if (!defined('LN_MY_IP')) define('LN_MY_IP', '');
 if (!defined('LN_MY_PORT')) define('LN_MY_PORT', '9735');
 if (!defined('LN_FRACTION')) define('LN_FRACTION', 7); // Fraction of main BTC wallet to fund channels
-if (!defined('LN_MIN_PAY')) define('LN_MIN_PAY', 3000);
+if (!defined('LN_MIN_PAY')) define('LN_MIN_PAY', 1000); // min payout in satoshis
 if (!defined('LN_MAIN_NODE')) define('LN_MAIN_NODE', '');
 if (!define('YAAMP_LN_NET')) define('YAAMP_LN_NET', 'TESTNET'); // TESTNET or MAINET
 if (!define('YAAMP_LN_WORKERS')) define('YAAMP_LN_WORKERS', false);

--- a/web/yaamp/defaultconfig.php
+++ b/web/yaamp/defaultconfig.php
@@ -72,3 +72,13 @@ if (!defined('NICEHASH_DEPOSIT_AMOUNT')) define('NICEHASH_DEPOSIT_AMOUNT','0.01'
 // cli stuff
 if (!defined('YIIMP_CLI_ALLOW_TXS')) define('YIIMP_CLI_ALLOW_TXS', false);
 
+// Lightning Network
+if (!defined('LN_ENABLED')) define('LN_ENABLED', false);
+if (!defined('LN_ENABLED')) define('LN_MY_BTC_ADDRESS', '');
+if (!defined('LN_ENABLED')) define('LN_MY_LN_ADDRESS', '');
+if (!defined('LN_ENABLED')) define('LN_MY_IP', '');
+if (!defined('LN_ENABLED')) define('LN_MY_PORT', '9735');
+if (!defined('LN_ENABLED')) define('LN_FRACTION', 7); // Fraction of main BTC wallet to fund channels
+if (!defined('LN_ENABLED')) define('LN_MIN_PAY', 3000);
+if (!defined('LN_ENABLED')) define('LN_MIN_PAY', 10000);
+

--- a/web/yaamp/modules/site/SiteController.php
+++ b/web/yaamp/modules/site/SiteController.php
@@ -1194,7 +1194,7 @@ class SiteController extends CommonController
 
 	public function actionLn()
         {
-		if(LN_ENABLED == false || !$this->admin) return;
+		if(LN_ENABLED == false || (YAAMP_LN_NET == 'MAINET' && !$this->admin)) return;
                 $this->render('/site/ln');
         }
 }

--- a/web/yaamp/modules/site/SiteController.php
+++ b/web/yaamp/modules/site/SiteController.php
@@ -1192,4 +1192,8 @@ class SiteController extends CommonController
 		setcookie('mainbtc', '1', time()+60*60*24, '/');
 	}
 
+	public function actionLn()
+        {
+                $this->render('/site/ln');
+        }
 }

--- a/web/yaamp/modules/site/SiteController.php
+++ b/web/yaamp/modules/site/SiteController.php
@@ -1194,6 +1194,7 @@ class SiteController extends CommonController
 
 	public function actionLn()
         {
+		if(LN_ENABLED == false || !$this->admin) return;
                 $this->render('/site/ln');
         }
 }

--- a/web/yaamp/modules/site/index.php
+++ b/web/yaamp/modules/site/index.php
@@ -75,6 +75,7 @@ if (YAAMP_LN_WORKERS == true)	{
 	?>the workername to send the invoice. Example:
 	<p class="main-left-box" style='padding: 3px; font-size: .8em; background-color: #ffffee; font-family: monospace;'>
 	-o stratum+tcp://<?= YAAMP_STRATUM_URL ?>:&lt;PORT&gt; -u &lt;WALLET_ADDRESS&gt;.&lt;invoice&gt; [-p &lt;OPTIONS&gt;]</p>
+	Lightning Network invoices can be generated from a LN wallet or directly on a merchant's website (<a href="http://lightningnetworkstores.com/">List of merchants (mainet)</a>, <a href="http://lightningnetworkstores.com/testnet">List of merchants (testnet)</a>).
 	<?php
 	}
 endif; ?>

--- a/web/yaamp/modules/site/index.php
+++ b/web/yaamp/modules/site/index.php
@@ -67,6 +67,17 @@ $payout_freq = (YAAMP_PAYMENTS_FREQ / 3600)." hours";
 <?php endif; ?>
 <li>As optional password, you can use <b>-p c=&lt;SYMBOL&gt;</b> if yiimp does not set the currency correctly on the Wallet page.</li>
 <li>See the "Pool Status" area on the right for PORT numbers. Algorithms without associated coins are disabled.</li>
+<?php if (LN_ENABLED): ?>
+Lightning Network payments are enabled on this pool on <b><?php echo YAAMP_LN_NET; ?></b>. You can send Lightning Network invoices using <?php
+if (YAAMP_LN_NET == 'TESTNET') echo '<a href="/site/ln">LN page</a>';
+if (YAAMP_LN_NET == 'TESTNET' && YAAMP_LN_WORKERS == true) echo ' or ';
+if (YAAMP_LN_WORKERS == true)	{
+	?>the workername to send the invoice. Example:
+	<p class="main-left-box" style='padding: 3px; font-size: .8em; background-color: #ffffee; font-family: monospace;'>
+	-o stratum+tcp://<?= YAAMP_STRATUM_URL ?>:&lt;PORT&gt; -u &lt;WALLET_ADDRESS&gt;.&lt;invoice&gt; [-p &lt;OPTIONS&gt;]</p>
+	<?php
+	}
+endif; ?>
 
 <br>
 

--- a/web/yaamp/modules/site/ln.php
+++ b/web/yaamp/modules/site/ln.php
@@ -1,0 +1,240 @@
+<?php
+
+JavascriptFile("/extensions/jqplot/jquery.jqplot.js");
+JavascriptFile("/extensions/jqplot/plugins/jqplot.dateAxisRenderer.js");
+JavascriptFile("/extensions/jqplot/plugins/jqplot.barRenderer.js");
+JavascriptFile("/extensions/jqplot/plugins/jqplot.highlighter.js");
+JavascriptFile("/extensions/jqplot/plugins/jqplot.cursor.js");
+JavascriptFile('/yaamp/ui/js/auto_refresh.js');
+
+echo <<<END
+<!--
+<div id='resume_update_button' style='color: #444; background-color: #ffd; border: 1px solid #eea;
+        padding: 10px; margin-left: 20px; margin-right: 20px; margin-top: 15px; cursor: pointer; display: none;'
+        onclick='auto_page_resume();' align=center>
+        <b>Auto refresh is paused - Click to resume</b></div>
+-->
+<table cellspacing=20 width=100%>
+<tr><td valign=top width=50%>
+END;
+
+echo <<<END
+<div class="main-left-box">
+<div class="main-left-title">Lightning Network (testnet)</div>
+<div class="main-left-inner">
+END;
+
+//echo "<h1>Lightning Network (testnet)</h1>";
+
+echo "<p>Lightning Network (LN) is a second-layer network based on bitcoin on-chain transactions. ";
+echo "It allows to perform bitcoin transactions with less fees and high speed.</p>";
+//echo "More informations: <a href=\"https://lightning.network/\">lightning.network</a></p>";
+echo "<p><b>This page allows you to pay LN bills/invoices on testnet for any service on testnet.</b></p>";
+
+//echo "<h2> ?</h2>";
+?>
+
+
+<ul>
+<!--
+<li>Bitcoin, altcoins and mining pools are still in development.</li>
+<li>This pool allows miners to pay any testnet bill from <a href="https://testnet.millionbitcoinhomepage.net/">The Million Bitcoin Homepage</a>
+(but you can also try with yaals, Starblocks or testnet.satoshis.place) using testnet coins.</li>
+<b>How to use ?</b>
+<li>1. Go to <a href="https://testnet.millionbitcoinhomepage.net/">The Million Bitcoin Homepage</a>,</li>
+<li>2. Make a drawing, click on "Publish your pixels",</li>
+<li>3. Copy/paste the payment request (invoice bolt11 reference) into the field here below and click on "Pay my testnet bill".</li>
+<li>4. Refresh the page to make sure that the payment was executed.</li>
+-->
+<?php
+
+$bill = getparam('bill');
+if (!empty($bill) && preg_match('/[^A-Za-z0-9]/', $bill)) {
+echo "<b>Please type a bolt11 testnet bill. <a href='/site/ln'>Try again</a></b>";
+//      die;
+}
+else if (!empty($bill)) {
+// Save bill (or pay it directly if enough funds)
+$db_bill = getdbosql('db_invoices', "bolt11=:bolt11", array(':bolt11'=>$bill));
+// etdbo('db_invoices', $bill);
+
+if (!$db_bill)  {
+        echo  <<<END
+<br />
+<div class="main-left-box">
+<div class="main-left-title">Invoice payment status</div>
+<div class="main-left-inner">
+<p>
+        <b>Your invoice was saved in the list of invoices to pay</b>, it will be paid soon. Please refresh this page in few seconds.<br />
+A scheduled task is running once per 20 seconds to pay automatically all bills in the list.
+</p>
+</div></div>
+END;
+        dborun("INSERT IGNORE INTO invoices(bolt11, status) VALUES (:key,:val)", array(
+                ':key'=>$bill,':val'=>"New"
+        ));
+}
+else    {
+        echo <<<END
+<br />
+<div class="main-left-box">
+<div class="main-left-title">Invoice payment status</div>
+<div class="main-left-inner">
+END;
+        echo "<p><b>This bill is already into the list of bills.</b><br />";
+        echo "Its status is: <b>".$db_bill->status."</b><br />";
+        switch ($db_bill->status)       {
+                case 'New':
+                        echo "<b>The scheduled task did not run yet, your invoice will be processed in a short while.</b>";
+                        break;
+                case 'maxfee':
+                        echo "<b>The fee associated with your invoice is too high compared to the invoice amount. As the maximum fee is 4% for normal invoices, your invoice won't be paid. Please try again with a higher amount.</b>";
+                        break;
+                case 'synok':
+                        echo "<b>Synthax and destinator of the bill are correct.</b>";
+                        break;
+                case 'underpay':
+                        echo "Payment of bill is <b>ongoing</b>.";
+                        break;
+                case 'complete':
+                        echo "<b style='color: green;'>Bill of ".$db_bill->amount." millisatoshi is paid (";
+                        echo number_format($db_bill->amount / 1000, 0)." satoshi = ";
+                        echo number_format($db_bill->amount / 100000000000, 8)." bitcoin).</b><br />";
+                        echo "Fee was ".($db_bill->paid - $db_bill->amount)." millisatoshi (";
+                        echo number_format(100*($db_bill->paid - $db_bill->amount)/$db_bill->amount, 2)." %)";
+                        break;
+                default:
+                        echo "Err";
+        }
+echo "</p><p>";
+global $configLNGamePlayers;
+$found = false;
+if ($db_bill->shop != "")       {
+//echo $db_bill->shop;
+//var_dump($db_bill);
+        foreach ($configLNGamePlayers as $name => $player)      {
+                if ($player[0] == $db_bill->shop)       {
+                        echo "<b>Shop:</b> <a href='http://$name'>".$name."</a> (".$db_bill->shop.") ";
+                        $found = true;
+                        break;
+                        }
+                }
+        if ($found == false)    {
+                echo "<b>Shop:</b> Unknown shop (".$db_bill->shop.").";
+                }
+
+echo "<br /><b>Amount:</b> ".$db_bill->amount. " millisatoshi (";
+                        echo number_format($db_bill->amount / 1000, 3)." satoshi = ";
+                        echo number_format($db_bill->amount / 100000000000, 11)." bitcoin).<br />";
+echo "<b>Description:</b> ".$db_bill->description;
+        }
+echo "</p></div></div>";
+
+}
+echo "<br />";
+echo "<p>Please refresh this screen to check the status of payment of the testnet bill.<br /></p>";
+
+}
+else
+echo <<<END
+<br />
+<div class="main-left-box">
+<div class="main-left-title">Pay testnet bill:</div>
+<div class="main-left-inner">
+<form method="GET" action="/site/ln" style="padding: 10px;">
+<label for="bill">Enter your testnet bill:</label>
+<input type="text" name="bill" class="main-text-input" placeholder="invoice"/>
+<input type="submit" value="Pay invoice"  class="main-submit-button" />
+<br />
+<br />
+Your testnet bill should be created on a testnet shop such as <a href="https://testnet.millionbitcoinhomepage.net/">The Million Bitcoin Homepage</a> or another testnet shop that works with the LN node of the pool.
+</form>
+</div></div>
+<br />
+END;
+
+echo <<<END
+<div class="main-left-box">
+<div class="main-left-title">How to use ?</div>
+<div class="main-left-inner">
+<ul>
+<li><b>Bitcoin, altcoins and mining pools are still in development.</b></li>
+<li>This pool allows miners to pay any testnet bill from <a href="https://testnet.millionbitcoinhomepage.net/">The Million Bitcoin Homepage</a>
+(but you can also try with other LN testnet merchants such as <a href="https://yalls.org/">yaals</a>, <a href="https://starblocks.acinq.co/">
+Starblocks</a> or <a href="https://testnet.satoshis.place/">testnet.satoshis.place</a>) with Lightning Network on Bitcoin testnet.</li>
+<b>How to use ?</b>
+<li>1. Go to <a href="https://testnet.millionbitcoinhomepage.net/">The Million Bitcoin Homepage</a>,</li>
+<li>2. Make a drawing, click on "Publish your pixels",</li>
+<li>3. Copy/paste the payment request (invoice bolt11 reference) into the field here below and click on "Pay my testnet bill".</li>
+<li>4. Refresh the page to make sure that the payment was executed.</li>
+
+</div></div>
+
+<br />
+
+<div class="main-left-box">
+<div class="main-left-title">How does it work ?</div>
+<div class="main-left-inner">
+<p>
+<ul>
+<li>It is based on magic enhanced features of Bitcoin and Lightning Network. Integration within YiiMP will be released as opensource soon.</li>
+<li>More informations: <a href="https://lightning.network/">lightning.network</a></li>
+<li><a href="http://lightningnetworkstores.com/testnet">Testnet stores list</a></li>
+<li><a href="https://github.com/phm87/LN-testnet-list">Testnet Ressources list</a></li>
+</ul>
+</p>
+END;
+
+echo "</div></div>
+<br />";
+?>
+<br />
+
+</ul>
+
+
+<?php
+echo "</td><td valign=top>";
+echo <<<END
+<div id='pool_current_results'>
+<br><br><br><br><br><br><br><br><br><br>
+</div>
+END;
+
+echo <<<END
+</td></tr></table>
+
+<script>
+function page_refresh()
+{
+        pool_current_refresh();
+        pool_history_refresh();
+}
+function select_algo(algo)
+{
+        window.location.href = '/site/algo?algo='+algo+'&r=/';
+}
+////////////////////////////////////////////////////
+function pool_current_ready(data)
+{
+        $('#pool_current_results').html(data);
+}
+function pool_current_refresh()
+{
+        var url = "/site/current_results";
+        $.get(url, '', pool_current_ready);
+}
+////////////////////////////////////////////////////
+function pool_history_ready(data)
+{
+        $('#pool_history_results').html(data);
+}
+function pool_history_refresh()
+{
+        var url = "/site/history_results";
+        $.get(url, '', pool_history_ready);
+}
+</script>
+
+END;
+?>

--- a/web/yaamp/modules/thread/CronjobController.php
+++ b/web/yaamp/modules/thread/CronjobController.php
@@ -39,15 +39,7 @@ class CronjobController extends CommonController
 		}
 	}
 
-        public function actionRunStartLightning()
-        {
-              debuglog(__METHOD__);
-                set_time_limit(0);
-                 $output = shell_exec('lightningd --bitcoin-rpcconnect=192.168.10.35 --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=Test');
-                $output = json_decode($output);
-                debuglog($output);
-        }
-
+	
         public function actionRunLightning()
         {
               debuglog(__METHOD__);

--- a/web/yaamp/modules/thread/CronjobController.php
+++ b/web/yaamp/modules/thread/CronjobController.php
@@ -39,6 +39,330 @@ class CronjobController extends CommonController
 		}
 	}
 
+        public function actionRunStartLightning()
+        {
+              debuglog(__METHOD__);
+                set_time_limit(0);
+                 $output = shell_exec('lightningd --bitcoin-rpcconnect=192.168.10.35 --bitcoin-rpcuser=bitcoin --bitcoin-rpcpassword=Test');
+                $output = json_decode($output);
+                debuglog($output);
+        }
+
+        public function actionRunLightning()
+        {
+              debuglog(__METHOD__);
+                set_time_limit(0);
+
+//                $this->monitorApache();
+
+                $last_complete = memcache_get($this->memcache->memcache, "cronjob_ln_time_start");
+
+                // debuglog("Lightning turned on ?");
+                $output = shell_exec('sudo lightning-cli -J getinfo');
+                $output = json_decode($output);
+
+                $lightning = false;
+                foreach ($output as $key => $out)
+                        {
+                        if ($key == 'id')       {
+                                debuglog("[LN] 1. Lightning is turned ON: OK");
+                                debuglog("[LN] My LN id = $out");
+                                $lightning = true;
+                                }
+                        }
+		                if (!$lightning)
+                        debuglog("[LN] Error: Please run lightningd in a screen");
+                else    {
+
+
+                debuglog("[LN] 2. Check LN BTC address");
+                $outpute = shell_exec("sudo lightning-cli -J dev-listaddrs");
+                $output = json_decode($outpute);
+                //debuglog("ok");
+//              debuglog($outpute);
+
+                $found = false;
+                //if (isset($output->addresses))
+                foreach ($output->addresses as $out)        {
+//                      debuglog("in"); // value = ".$out["value"]." status = ".$out["status"]);
+                        if (LN_MY_BTC_ADDRESS == $out->p2sh)    {
+                                $found = true;
+                                debuglog("[LN] LN_MY_BTC_ADDRESS found and own : OK");
+                                break;
+                        }
+                }
+                if ($found == false)    {
+                        debuglog("[LN] Error: Please create a p2sh-segwit address using lightning-cli newaddr then fill LN_MY_BTC_ADDRESS");
+                }
+                else    {
+
+                debuglog("[LN] 3. Check funds");
+
+                $output = shell_exec("sudo lightning-cli -J listfunds");
+                $listfunds = json_decode($output);
+//              debuglog($output);
+
+                $ln_balance = 0;
+
+                $found = false;
+                if (count($listfunds->outputs) > 0)
+                foreach ($listfunds->outputs as $out)        {
+//                      debuglog("in"); // value = ".$out["value"]." status = ".$out["status"]);
+                        if ($out->status == "unconfirmed" && $out->output == 1 && count($listfunds->channels) > 0)      {
+                                debuglog("[LN] Channel creation ongoing");
+                                $found = true;
+                        }
+			
+		                        if ($out->status == "confirmed" && $out->output == 1 && count($listfunds->channels) > 0 && $out->value > 100)      {
+                                $ln_balance = $out->value;
+                                debuglog("[LN] seems ok, to analyse later");
+                                $found = true;
+                        }
+                        if ("confirmed" == $out->status && 0 == $out->output && count($listfunds->channels) > 0)    {
+                                $ln_balance = $out->value;
+                                $found = true;
+                                debuglog("[LN] Initial funding onchain : OK");
+                                break;
+                        }
+                }
+                if ($found == false)    {
+                        debuglog("[LN] Error: Please perform a Bitcoin onchain transaction to ".LN_MY_BTC_ADDRESS);
+// testnet faucet : https://testnet.manu.backend.hamburg/faucet
+                }
+                else    {
+
+                debuglog("LN Balance (not in channels) = ".$ln_balance." sat = ".($ln_balance/100000000)." BTC");
+
+                debuglog("[LN] 4. Check connections");
+
+                $output = shell_exec('sudo lightning-cli -J listpeers');
+                $output = json_decode($output);
+			
+		                global $configLNGamePlayers;
+                foreach ($configLNGamePlayers as $player)       {
+//debuglog($player[0]);
+                        $connected = false;
+                        foreach ($output->peers as $out)        {
+                                if ($out->id == $player[1])     {
+                                        debuglog("Connected to player OK");
+                                        $connected = true;
+                                        break;
+                                }
+                        }
+                        if ($connected == false)        {
+                                debuglog("Connect to player...");
+                                $ttt = 'sudo lightning-cli -J connect ' . $player[1] . ' ' . $player[2] . ' ' . $player[3]; // . "'";
+                                //debuglog("OK");
+                                debuglog($ttt);
+
+                                $output = shell_exec($ttt);
+                                debuglog($output);
+                                // todo: handle errors to avoid this peer (into memcache ?)
+                                // -1, "message" : "Connection establishment: Connection timed out
+                        }
+                }
+
+                debuglog("[LN] 5. Check channels funds : cancelled !");
+
+//                $output = shell_exec('sudo lightning-cli -J list');
+//                $output = json_decode($output);
+                $found = true;
+/*                if (count($listfunds->channels) > 0)
+                foreach ($listfunds->channels as $out)        {
+//                      debuglog("in"); // value = ".$out["value"]." status = ".$out["status"]);
+                        if ($out->channel_sat > 100 && isset($out->id_peer) && $out->id_peer == LN_MAIN_NODE)    {
+                                $found = true;
+                                debuglog("[LN] Channel credit > 100 : OK");
+                                //break;
+                        }
+                        else    {
+                                debuglog("[LN] Channel $out->peer_id with less than 100 !!! To refund ...");
+                                // I dont think that the function to refund a channel is already developped in LN ...
+		                                $output = shell_exec('sudo lightning-cli close '.$out->id_peer); //. ' ' . max( 16777215, round($ln_balance / LN_FRACTION)));
+                                $output = json_decode($output);
+                                debuglog($output);
+                                break;
+                        }
+                }
+*/
+                if ($found == false)    {
+                        debuglog("[LN] No channels credited: Channel credit with a fraction of the remaining funds");
+                        //foreach ($configLNGamePlayers as $player)       {
+                                //  code : -32602    [message] => 'Funding satoshi must be <= 16777215'
+//                              $output = shell_exec('sudo lightning-cli -J fundchannel '.$out->id_peer. ' ' . min( 16777215, round($ln_balance / LN_FRACTION)));
+//                              $output = json_decode($output);
+//                              debuglog($output);
+                        //}
+
+                }
+                else    {
+                        debuglog("[LN] 6. Channel open on LN : cancelled !");
+/*
+                        $outpute = shell_exec('sudo lightning-cli -J listpeers');
+                        $output = json_decode($outpute);
+//debuglog($outpute);
+                        $found = true; // false;
+                        if (isset($output->peers))
+                                if(count($output->peers) > 0)
+                        foreach ($output->peers as $out)        {
+                                debuglog("Peer ".$out->alias);
+                                if (count($out->channels) > 0)
+                                foreach ($out->channels as $o)        {
+                                        if ($o->state == "CHANNELD_AWAITING_LOCKIN")    {
+                                                debuglog("[LN] Waiting for 3 to 6 confirmations on bitcoin network. CHANNELD_AWAITING_LOCKIN:Funding needs more confirmations.");
+                                        }
+                                        if ($o->state == "CHANNELD_NORMAL")    {
+                                                debuglog("[LN] Channel open : OK");
+                                        }
+                                        if ($o->state == "GOSSIPING")    {
+                                                $output = shell_exec('sudo lightning-cli -J fundchannel '.$out->id_peer. ' ' . min( 16777215, round($ln_balance / LN_FRACTION)));
+                                                $output = json_decode($output);
+                                                debuglog($output);
+                                        }
+                                        if ($o->state == "ONCHAIN")
+                                                && in_array("ONCHAIN:All outputs resolved: waiting 99 more blocks before forgetting channel", $o->states))      {
+                                                $output = shell_exec('sudo lightning-cli -J fundchannel '.$out->id_peer. ' ' . min( 16777215, round($ln_balance / LN_FRACTION)));
+                                                $output = json_decode($output);
+                                                debuglog($output);
+                                        }
+                                }
+                        }
+                        debuglog("channels chekcs ended");
+*/
+                        if (true)       {
+                                debuglog("Payment will be done");
+
+                                if (true) { // $ln_balance > LN_MIN_PAY)        {
+
+$db_bills = dbolist("SELECT bolt11 from invoices WHERE status='New' ORDER by id ASC");
+if (!$db_bills)  {
+        debuglog("Nothing to pay");
+        }
+else    {
+        debuglog("To pay");
+        foreach ($db_bills as $bill)    {
+//              debuglog("Bill");
+//              break;
+//              }
+//      }
+
+//if (!empty($bill) && preg_match('/[^A-Za-z0-9]/', $bill)) {
+//echo "<b>Please type a bolt11 testnet bill. <a href='/'>Try again</a></b>";
+//      die;
+//}
+
+//              debuglog("before");
+//              debuglog($bill['bolt11']);
+                $oo = "sudo lightning-cli -J decodepay ".$bill['bolt11'];
+		                debuglog($oo);
+                $outpute = shell_exec($oo);
+                $output = json_decode($outpute);
+                debuglog($outpute);
+                if (isset($output->message) && $output->message == "Invalid bolt11: Bad bech32 string")   {
+                        // debuglog("clean invalid");
+                        dborun("UPDATE invoices SET status = 'Invalid' WHERE bolt11='".$bill['bolt11']."'");
+                        debuglog("Invoice with invalid bolt11");
+                        break;
+                        }
+                if (isset($output->description))        {
+                        dborun("UPDATE invoices SET description = '".addslashes(htmlentities($output->description))."' WHERE bolt11='".$bill['bolt11']."'");
+                        debuglog("Update description");
+                        }
+                if (isset($output->payee))  {
+                        dborun("UPDATE invoices SET shop = '".$output->payee."' WHERE bolt11='".$bill['bolt11']."'");
+                        debuglog("Update shop");
+                        }
+                if (isset($output->msatoshi))  {
+                        dborun("UPDATE invoices SET amount = '".$output->msatoshi."' WHERE bolt11='".$bill['bolt11']."'");
+                        debuglog("Update amount");
+                        }
+
+                $oo = "sudo lightning-cli -J pay maxfeepercent=4 maxdelay=1200 bolt11=".$bill['bolt11'];
+                debuglog($oo);
+                $outpute = shell_exec($oo);
+//              debuglog("ok");
+                $output = json_decode($outpute);
+                debuglog($outpute);
+                if (isset($output->message) && $output->message == "Invoice expired")   {
+                        dborun("UPDATE invoices SET status = 'Expired' WHERE bolt11='".$bill['bolt11']."'");
+                        debuglog("Invoice expired");
+                        break;
+                        }
+
+                if (isset($output->message) && $output->message == "Invalid bolt11: Bad bech32 string")   {
+                        // debuglog("clean invalid");
+                        dborun("UPDATE invoices SET status = 'Invalid' WHERE bolt11='".$bill['bolt11']."'");
+                        debuglog("Invoice with invalid bolt11");
+                        break;
+                        }
+		                if (isset($output->message) && (strpos($output->message == "max fee requested is")  !== false)) {
+                        // Fee 2001 is 1.352941% of payment 147900; max fee requested is
+                        // debuglog("clean invalid");
+                        dborun("UPDATE invoices SET status = 'maxfee' WHERE bolt11='".$bill['bolt11']."'");
+                        debuglog("Invoice with too much fee.");
+                        break;
+                        }
+
+                if (isset($output->status) && $output->status == "complete")   {
+                        // debuglog("clean invalid");
+                        dborun("UPDATE invoices SET status = 'complete', exectime = '".time()."' WHERE bolt11='".$bill['bolt11']."'");
+                        debuglog("Bill paid ! :-)");
+                        if (isset($output->msatoshi_sent))      {
+                                dborun("UPDATE invoices SET paid = '".$output->msatoshi_sent."' WHERE bolt11='".$bill['bolt11']."'");
+                                }
+                        break;
+                        }
+
+/*
+
+                                        //debuglog($output);
+//                                      if ($output->msatoshi == LN_MIN_PAY * 1000)     { // * 1000 because millisat
+                                                $outpute = shell_exec('sudo lightning-cli -J pay '.$bill);
+                                                $output = json_decode($outpute);
+                                                debuglog($outpute);
+                                                if ($output->code == 206) // "code" : 206, "message" : "Delay (locktime) is 576 blocks; max delay requested is 500."
+                                                // https://github.com/ElementsProject/lightning/issues/1586 issue still opened
+                                                {
+                                                        $outpute = shell_exec('sudo lightning-cli -J pay maxdelay=577 bolt11='.$bill);
+                                                        $output = json_decode($outpute);
+                                                        debuglog($outpute);
+                                                }
+                                                if ($output->code == 200) //  "code" : 200, "message" : "Stopped retrying during payment attempt; continue monitoring with pay or listpayments"
+                                                {
+                                                        debuglog("[LN] Err 200: Stopped retrying during payment attempt; continue monitoring with pay or l");
+                                                }
+                                                if ($output->code == 205) //   "code" : 205, "message" : "Could not find a route"
+                                                {
+                                                         debuglog("[LN] Err 205");
+                                                }
+                                        }
+                                        else
+                                                debuglog("[LN] Bill: bad amount ".$output->msatoshi." ".(LN_MIN_PAY * 1000));
+
+*/
+break;
+                }
+        }
+
+
+//                                      $bill = file_get_contents("");
+                                }
+				                        }
+                        //debuglog($outpute);
+                }
+
+                //debuglog($output["id"]);
+                //debuglog("Refund channel if new payment occured");
+
+                }
+                }
+                }
+
+                memcache_set($this->memcache->memcache, "cronjob_ln_time_start", time());
+//              debuglog(__METHOD__);
+        }
+	
+	
 	public function actionRunBlocks()
 	{
 //		screenlog(__FUNCTION__);

--- a/web/yaamp/ui/main.php
+++ b/web/yaamp/ui/main.php
@@ -121,11 +121,11 @@ function showPageHeader()
 		if (YAAMP_USE_NICEHASH_API)
 			showItemHeader(controller()->id=='nicehash', '/nicehash', 'Nicehash');
 		
-		if (YAAMP_LN_ENABLED)
+		if (LN_ENABLED)
 			showItemHeader(controller()->id=='ln', '/site/ln', 'LN');
 	}
 	
-	if (YAAMP_LN_ENABLED && YAAMP_LN_NET == 'TESTNET' && !controller()->admin)
+	if (LN_ENABLED && YAAMP_LN_NET == 'TESTNET' && !controller()->admin)
 		showItemHeader(controller()->id=='ln', '/site/ln', 'LN (testnet)');
 	
 	echo '<span style="float: right;">';

--- a/web/yaamp/ui/main.php
+++ b/web/yaamp/ui/main.php
@@ -121,11 +121,13 @@ function showPageHeader()
 		if (YAAMP_USE_NICEHASH_API)
 			showItemHeader(controller()->id=='nicehash', '/nicehash', 'Nicehash');
 		
-		if (LN_ENABLED)
+		if (YAAMP_LN_ENABLED)
 			showItemHeader(controller()->id=='ln', '/site/ln', 'LN');
-		
 	}
-
+	
+	if (YAAMP_LN_ENABLED && YAAMP_LN_NET == 'TESTNET' && !controller()->admin)
+		showItemHeader(controller()->id=='ln', '/site/ln', 'LN (testnet)');
+	
 	echo '<span style="float: right;">';
 
 	$mining = getdbosql('db_mining');

--- a/web/yaamp/ui/main.php
+++ b/web/yaamp/ui/main.php
@@ -120,6 +120,10 @@ function showPageHeader()
 
 		if (YAAMP_USE_NICEHASH_API)
 			showItemHeader(controller()->id=='nicehash', '/nicehash', 'Nicehash');
+		
+		if (LN_ENABLED)
+			showItemHeader(controller()->id=='ln', '/site/ln', 'LN');
+		
 	}
 
 	echo '<span style="float: right;">';


### PR DESCRIPTION
WORK IN PROGRESS - Dangerous !

TESTNET Development: OK
MAINET Development: in progress (please feel free to review/comment the logic, ideas and the code)


Using Lightning Network to pay miners instead of onchain (bitcoin) payments will reduce payment fees allowing to pay miners more frequently and for small amounts. This will reduce risk as funds will be paid more quickly.

Pool LN node/wallet will pay invoices of miners so only few channels will be created and funded properly. Pool operator maintains one pool LN wallet/node for all miners leading to reduce the number of potential problems. Onchain payments are used as fallback payment method or to pay the balance not paid using LN. If miners sends a stream of invoices, all balances can be paid on LN leading to reduce fees and avoid onchain transactions when possible.

Payments with LN can be used with several altcoins that implemented LN from bitcoin so it can be used with and without auto-exchange.
BTC, LTC, VTC, VIA, stellar lumens, Bitcoin private, Ravencoin, DCR
Nimiq, FTC, GRS, CHIPS, SYS, ...
https://bitcointalk.org/index.php?topic=1891745.0
https://bitcointalk.org/index.php?topic=1777136


To set up the Bitcoin and Lightning Network nodes, I used this tutorial:
https://andrewgriffithsonline.com/blog/180330-how-to-setup-a-lightning-node/
But it may be better to use lnd rather than c-lightning.


The implementation of LN into yiimp will be splitted into several versions of the code.

V0: Testnet (invoice into workername)
All visitors are able to send invoices to pay on testnet without restrictions using /site/ln
Pool operator should setup a BTC (or altcoin) node, a LN node, create and fund some channels prior to be able to pay invoices.
YAAMP_LN_NET should be set to TESTNET and YAAMP_LN_ENABLED set to true and YAAMP_LN_WORKERS to true or false. Setting YAAMP_LN_WORKERS to true allows the miners to send each invoice using the workername.
As each LN invoice should be passed by the webpage or with the workername by reconnecting the worker, this solution is inefficient, it is a proof-of-concept.

This development is finished and published to allow reviewing.


V1: Mainet
- move invoice INSERT into runLightning loop + adapt payment loop based on DB only + forbid to insert invoices if payments are going on
- SQL enhancement to select NEW invoices/workernames
- enhance LN string check
- add a help text for LN on index
- finish fees calculations
- display invoices on miner's personnal wallet page
- disable balance reduction if TESTNET but keep calculations for worker work

V2:
- rpc instead of direct calls
- add a hacker detector for LN (similar logic to "too many bad submits per second")
- fill automatically the LN BTC address, create channels and fund the channels

V3:
- stream of invoices (ccminer change needed + stratum)
- several workers to pay the same 

V4:
- pay invoices of high amount with a short expiry period (Possible to use miner's existing balance safely if the stream of invoices if secured enough)



Security:
---------

LN introduces new potential problems:


1. Wrong invoices (missing characters, additional spaces, wrong enconding, invoice without amount, expired invoice)
1.1 In the V1 of the implementation, as the workername is used to let the miner send the LN invoice, the string will follow the same restrictions of the workername. In addition, if there is an additional space or a wrong character, it won't be taken into account as an invoice and it will be taken into account as a normal workername.
https://github.com/tpruvot/yiimp/blob/next/stratum/client.cpp#L225

1.2 Some checks should be implemented to verify that the invoice is not expired.
1.3 A default LN payment value can be defined to be able to pay invoices without an amount (e.g. 1000 sat).

2. Fake invoices (invoice sent for another miner)
A malicious miner could send an invoice trying to be paid on the balance of another miner.
In the V1 of the implementation, an accounting per worker and submission of the invoice using the workername will prevent such an attack.
In the V3 of the implementation, a stream of invoice is sent by ccminer to yiimp stratum. If accounting per worker is kept and that the stream of invoices is secured, the attack won't be possible.

3. Several disconnections/reconnections of a worker
Yiimp stratum have already some features for this.

4. heavy load if "DDoS" of good/wrong/fake invoices
Logic and code enhancement can reduce this problem. Future log analysis will help.
The hacker detector forseen in V2 will address this problem more efficiently.

5. LN fees :
As the aim is to be able to pay all LN invoices, the fees related to the "route information" provided should be taken into account:
https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#on-mainnet-with-fallback-address-1rustyrx2oai4eyydpqgwvel62bbgqn9t-with-extra-routing-info-to-go-via-nodes-029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255-then-039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255

In particular, a malicious miner could set up several LN nodes with high routing fees and generate an invoice from a LN wallet that is reachable only via the miner's nodes. When the invoice with extra routing info is paid, the miner would receive his payment and collect the high routing fees introduced by his malicious LN nodes. The LN network itself is able to prevent this kind of cases in a normal situation: all other nodes would be incentived to create channels with the miner's wallet to bypass the malicious nodes. The concurrence between LN nodes to route payment and receive the routing fees.

When paying an invoice with LN, there are some limits/checks on fees:
"The 'maxfeepercent' limits the money paid in fees, and defaults to 0.5.
The `maxfeepercent' is a percentage of the amount that is to be
paid.
The `exemptfee` option can be used for tiny payments which would be dominated by
the fee leveraged by forwarding nodes. Setting `exemptfee` allows the
`maxfeepercent` check to be skipped on fees that are smaller than `exemptfee`
(default: 5000 millsatoshi)."
https://github.com/ElementsProject/lightning/blob/master/doc/lightning-pay.7.txt#L22

The malicious miner with control over some LN nodes as described here above would be incentived to send invoices with an amount below the 'exemptfee' of 5 satoshis. So in this implementation, the minimum amount of each invoice could be set to 6 satoshis.
https://github.com/ElementsProject/lightning/pull/1765

But based on tests on testnet, for some huge LN nodes that receive payments, fees are too high. So, if the payments fees are still paid by the pool, the minimum amount can be set to 100 but in some situations, 1000 satoshis can be a better choice. We'll keep 1000 sat (0.06€ in september 2018).

Question: are the extra routing info mandatory to follow ?
=> This question was raised in the LND Slack, see (Q1)

Whatever the extra routing info are mandatory or not (to follow), the 'maxfeepercent' will make this attack not possible or not profitable.
As it is not possible to know if a LN node used for routing is malicious (high fees and forced topology) or not, a standard limitation on the sum of routing fees would be sufficient. It is not possible to forbid miners to set up LN nodes to obtain the routing fees.

(Q1)
Hi,
I'd like to know if it is mandatory to use the routing nodes provided in an invoice as "extra routing info to go via nodes x y z". If someone sets up several LN nodes and force the topology to be sure that payments to his wallet will be routed through his nodes, can he get routing fees ? How to prevent such a case ?
Thank you

https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#on-mainnet-with-fallback-address-1rustyrx2oai4eyydpqgwvel62bbgqn9t-with-extra-routing-info-to-go-via-nodes-029e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255-then-039e03a901b85534ff1e92c43c74431f7ce72046060fcf7a95c37e148f78c77255

moli:
@phm87 routing fees are very low, more likely he's losing money than making any

vegard:
we're starting to see routing fee limits, too. it's likely your node will just reject doing the payment if no suitable route is found. And too high fee makes it unsuitable.

moli:
i think the competition to earn Lightning fees when the network matures will be fun to watch, i don't think spammers will win
because the worst scenario is users would just have their channels opened directly to their targets (ie, who they want to pay)  and bypass spammers


> The increased security risks of Lightning
> Requirement to be online when receiving a payment: As explained above, before receiving a payment, the recipient needs to sign a reclaim transaction so that the sender knows they can reclaim their funds in the event of hostile channel closure or a refusal to sign. Therefore, to receive money requires a hot wallet, meaning that private keys are potentially exposed if a security incident occurs.
> Requirement to monitor the channel: Lightning Network participants or watchtowers may be required to actively monitor the payment channels. This could place a burden on users or watchtowers and potentially reduces the security of funds inside a channel relative to Bitcoin stored on-chain. There is a risk of missing a reclaim-transaction deadline, either due to a failure to appropriately monitor the channel or perhaps because of on-chain network congestion.
> Miners could censor channel-closing transactions: 51% of the hashrate may have the ability to steal funds from Lightning users by censoring a channel-closure transaction, in which the miner is the other party. Although the potential consequences of this type of attack are already devastating without Lightning, the Lightning Network potentially offers hostile miners a slightly larger attack surface.
> While each of these three factors alone may not be significant, the need to potentially expose one’s private keys to the Internet when receiving payments, the risk of a hostile channel closure, and the risk of miners censoring channel-redemption transactions combined result in significantly inferior security — although all these risks can be managed to some extent.
> 
> There is a risk that lazy or poorly informed users keep too much money in a channel and funds are lost or stolen due to one of these failure scenarios. There is also the risk that price volatility results in users keeping more funds in payment channels than they would otherwise have intended.

Extract from https://blog.bitmex.com/the-lightning-network/


Usual potential problems should also be taken into account:

1. SQL Injection (bolt11 string, description field of the invoice, LN Receiver's name)
1.1 the bolt11 string cannot be used to make injections as the checks of the workername are still applied
1.2 TODO: the description of the invoice should be more filtered
1.3 the LN Receiver's name is currently not retrieved and saved automatically. If it is performed, a filtering should be performed to prevent injections

2. XSS hacks
The filters decribed here above can be insufficient for "HTML hacks" when special characters are escaped in HTML or else to perform injections. No existing field in any form was modified. A new field was added into a new webpage /site/ln.php for testing purposes (admin only for mainet but you can open it for your visitors on testnet). Some checks to prevent XSS hacks were added to this new field.

3. Dangerous commands to forbid (similar to dumpprivkey, backupwallet)
Nothing found into the doc:
https://github.com/ElementsProject/lightning/tree/master/doc