### PR TITLE
rainforest: fix Windows build

### DIFF
--- a/stratum/algos/rainforest.c
+++ b/stratum/algos/rainforest.c
@@ -537,7 +537,7 @@ static inline uint32_t rf_rambox(uint64_t *rambox, uint64_t old) {
 }
 
 // write (_x_,_y_) at cell _cell_ for offset _ofs_
-static inline void rf_w128(uint64_t *cell, ulong ofs, uint64_t x, uint64_t y) {
+static inline void rf_w128(uint64_t *cell, unsigned long ofs, uint64_t x, uint64_t y) {
 #if defined(__ARM_ARCH_8A) || defined(__AARCH64EL__)
   // 128 bit at once is faster when exactly two parallelizable instructions are
   // used between two calls to keep the pipe full.


### PR DESCRIPTION
ulong is not defined there. Simply use "unsigned long" instead.