### PR TITLE
Fix all zcash coins block rewards

### DIFF
--- a/web/yaamp/core/backend/coins.php
+++ b/web/yaamp/core/backend/coins.php
@@ -197,9 +197,8 @@ function BackendCoinsUpdate()
 				if($template && isset($template['coinbasetxn']))
 				{
 					// no coinbasevalue in ZEC blocktemplate :/
-					$txn = $template['coinbasetxn'];
-					$coin->charity_amount = arraySafeVal($txn,'foundersreward',0)/100000000;
-					$coin->reward = $coin->charity_amount * 4 + arraySafeVal($txn,'fee',0)/100000000;
+					$subsidy = $remote->getblocksubsidy();
+					$coin->reward = arraySafeVal($subsidy,'miner',0);
 					// getmininginfo show current diff, getinfo the last block one
 					$mininginfo = $remote->getmininginfo();
 					$coin->difficulty = ArraySafeVal($mininginfo,'difficulty',$coin->difficulty);


### PR DESCRIPTION
This makes more sense. setting rpcencoding to ZEC should work with zcash forks

./zcash-cli getblocksubsidy
{
  "miner": 10.00000000,
  "founders": 2.50000000
}

./zcl-cli getblocksubsidy
{
  "miner": 12.50000000,
  "founders": 0.00000000
}

./zen-cli getblocksubsidy
{
  "miner": 8.75000000,
  "community": 1.25000000,
  "securenodes": 1.25000000,
  "supernodes": 1.25000000
}