### PR TITLE
Support dash 0.13

### DIFF
--- a/stratum/coinbase.cpp
+++ b/stratum/coinbase.cpp
@@ -500,17 +500,35 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 		}
 		if (masternode_enabled && masternode) {
 			bool started = json_get_bool(json_result, "masternode_payments_started");
-			const char *payee = json_get_string(masternode, "payee");
-			json_int_t amount = json_get_int(masternode, "amount");
-			if (payee && amount && started) {
-				npayees++;
-				available -= amount;
-				base58_decode(payee, script_payee);
-				bool masternode_use_p2sh = (strcmp(coind->symbol, "MAC") == 0);
-				if(masternode_use_p2sh)
-					p2sh_pack_tx(coind, script_dests, amount, script_payee);
-				else
-					job_pack_tx(coind, script_dests, amount, script_payee);
+			if (json_is_array(masternode)) {
+				for(int i = 0; i < masternode->u.array.length; i++) {
+					const char *payee = json_get_string(masternode->u.array.values[i], "payee");
+					json_int_t amount = json_get_int(masternode->u.array.values[i], "amount");
+					if (payee && amount && started) {
+						npayees++;
+						available -= amount;
+						base58_decode(payee, script_payee);
+						bool masternode_use_p2sh = (strcmp(coind->symbol, "MAC") == 0);
+						if(masternode_use_p2sh)
+							p2sh_pack_tx(coind, script_dests, amount, script_payee);
+						else
+							job_pack_tx(coind, script_dests, amount, script_payee);
+						//debuglog("%s masternode %s %u\n", coind->symbol, payee, amount);
+					}
+				}
+			} else {
+				const char *payee = json_get_string(masternode, "payee");
+				json_int_t amount = json_get_int(masternode, "amount");
+				if (payee && amount && started) {
+					npayees++;
+					available -= amount;
+					base58_decode(payee, script_payee);
+					bool masternode_use_p2sh = (strcmp(coind->symbol, "MAC") == 0);
+					if(masternode_use_p2sh)
+						p2sh_pack_tx(coind, script_dests, amount, script_payee);
+					else
+						job_pack_tx(coind, script_dests, amount, script_payee);
+				}
 			}
 		}
 		sprintf(payees, "%02x", npayees);

--- a/stratum/coinbase.cpp
+++ b/stratum/coinbase.cpp
@@ -507,12 +507,13 @@ void coinbase_create(YAAMP_COIND *coind, YAAMP_JOB_TEMPLATE *templ, json_value *
 					if (payee && amount && started) {
 						npayees++;
 						available -= amount;
-						base58_decode(payee, script_payee);
-						bool masternode_use_p2sh = (strcmp(coind->symbol, "MAC") == 0);
-						if(masternode_use_p2sh)
-							p2sh_pack_tx(coind, script_dests, amount, script_payee);
-						else
+						const char *script = json_get_string(masternode->u.array.values[i], "script");
+						if (script) {
+							p2sh_pack_tx(coind, script_dests, amount, script);
+						} else {
+							base58_decode(payee, script_payee);
 							job_pack_tx(coind, script_dests, amount, script_payee);
+						}
 						//debuglog("%s masternode %s %u\n", coind->symbol, payee, amount);
 					}
 				}


### PR DESCRIPTION
This finally fixes new Dash 0.13 style transactions and block templates. Mined transactions are accepted by Dash 0.13-based coin daemons. But this need more work for:
1. To support full compactSize coinbase_payload length (currently only len < 0xFD supported).
2. To fix the internal explorer UI to properly show new transactions (visual flaw only).
3. Maybe to fix UI for reward (it subtracts the MN reward from block reward, but it is not fixed yet for array style masternode payment list).
